### PR TITLE
test: run vitest from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "pnpm -r test",
-    "test:coverage": "pnpm -r test:coverage",
+    "test": "vitest",
+    "test:coverage": "vitest run --coverage",
     "prepare": "husky"
   },
   "keywords": [],

--- a/packages/apps/ds4ch/package.json
+++ b/packages/apps/ds4ch/package.json
@@ -9,9 +9,7 @@
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
-    "test": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@europeana/style": "^2.9.0",

--- a/packages/apps/ds4ch/vitest.config.ts
+++ b/packages/apps/ds4ch/vitest.config.ts
@@ -1,12 +1,19 @@
 import { defineVitestConfig } from "@nuxt/test-utils/config";
 import { coverageConfigDefaults } from "vitest/config";
+import { fileURLToPath } from "node:url";
 
 export default defineVitestConfig({
   test: {
-    include: ["**/*.spec.js"],
     coverage: {
       exclude: [...coverageConfigDefaults.exclude, "nuxt.config.ts"],
     },
+    extends: true,
     setupFiles: ["tests/unit.setup.ts"],
+    environment: "nuxt",
+    environmentOptions: {
+      nuxt: {
+        rootDir: fileURLToPath(new URL(".", import.meta.url)),
+      },
+    },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.spec.js"],
+    projects: ["packages/*/*"],
+  },
+});


### PR DESCRIPTION
In the setting up of unit testing thusfar, it has been limited to the apps/ds4ch package, with the root-level command running vitest recursively for all packages.

That implies that each package would need its own vitest config, which I think we want to avoid where possible.

To that end, this PR, which establishes a root-level vitest config, which would apply to all the packages unless they have their own in which case that would be used, and can optionally extend the root one, as the apps/ds4ch one does here.