### PR TITLE
feat: image with attribution component

### DIFF
--- a/packages/apps/ds4ch/.storybook/sample-data.js
+++ b/packages/apps/ds4ch/.storybook/sample-data.js
@@ -1,18 +1,4 @@
 export default {
-  illustrations: {
-    events:
-      "https://images.ctfassets.net/i01duvb6kq77/3o9KQ2GWTLnEdPkF1wNyPe/5a7d9a9e8c3d314e530e0c275ef152dd/illustration_events.svg",
-    newsletter:
-      "https://images.ctfassets.net/i01duvb6kq77/1tvbbzdiq0sc0hBjbqlihZ/a60ff9eb7d24df0b0a1e54ae19d3c3d9/il_newsletter.svg",
-    curate:
-      "https://images.ctfassets.net/i01duvb6kq77/1DxiDhy46cX5eBheNYFdP7/42518b79959f2ea5cd270f9cffa022b2/homepage_A_v4_blackline.svg",
-    audience:
-      "https://images.ctfassets.net/i01duvb6kq77/B0VJ9of5sryy5n34hS93I/991133dbbc2dd0f48fd215e3aa1c3c75/Audience.svg",
-    support:
-      "https://images.ctfassets.net/i01duvb6kq77/KIMCBhGmlm90mxG8hldb1/8339d01737e9456cd10715b40f6c1925/feedback.svg",
-    search:
-      "https://images.ctfassets.net/i01duvb6kq77/JX06hL2kGk2mqCJLsoJUh/4d8bad1506779f0029c00f5f522e8e00/search.svg",
-  },
   imagesWithAttribution: [
     {
       name: "Winter Landscape with Ice Skaters",
@@ -29,67 +15,5 @@ export default {
         height: 1691,
       },
     },
-    {
-      name: "Northern Lights. Study from North Norway",
-      creator: "Anna Boberg",
-      provider: "Nationalmuseum Sweden",
-      license: "https://creativecommons.org/publicdomain/mark/1.0/",
-      url: "https://www.europeana.eu/en/item/2064116/Museu_ProvidedCHO_Nationalmuseum__Sweden_21327",
-      image: {
-        url: "https://images.ctfassets.net/i01duvb6kq77/61Q1XSrSqAtoWypDH4k1bY/b774eb32406e198f9ba5cdc8970e3e8f/Europeana.eu-2064116-Museu_ProvidedCHO_Nationalmuseum__Sweden_21327-b8dd190867b87b651c5907f7b33c6ad7.jpeg",
-        description:
-          "painting, blue and white rays of light shine from behind a mountain.",
-        contentType: "image/jpeg",
-        width: 1000,
-        height: 842,
-      },
-    },
-    {
-      name: "Eight plants, including two orchids, a crocus and some tulips: flowering stems. Coloured etching, c.1837.",
-      creator: "Undefined",
-      provider: "Wellcome Collection",
-      license: "http://creativecommons.org/licenses/by/4.0/",
-      url: "http://data.europeana.eu/item/9200579/hxf3z8ek",
-      image: {
-        url: "https://images.ctfassets.net/i01duvb6kq77/1l8m0GQ9crP6zvts5zWYos/0006db953cc9a8a08a064c141cd78777/feature_botanical-illustrations.jpg",
-        contentType: "image/jpeg",
-        description:
-          "colour illustration of a bunch of colourful flowers in yellow, red, orange",
-        width: 830,
-        height: 470,
-      },
-    },
-  ],
-  itemPreviewCardData: {
-    dataProvider: ["United Archives / WHA"],
-    dcCreatorLangAware: { en: ["United Archives / WHA"] },
-    dcDescriptionLangAware: {
-      de: [
-        `French, Coloured illustration, dated circa 1884, depicting a frilled-necked lizard (Chlamydosaurus kingii), also known as the frilled lizard,
-    frilled dragon or frilled agama, is a species of lizard which is found mainly in northern Australia and southern N…`,
-      ],
-    },
-    dcTitleLangAware: {
-      en: ["illustration, circa 1884,depicting a frilled-necked lizard"],
-    },
-    edmPreview: [
-      "https://api.europeana.eu/thumbnail/v2/url.json?uri=http%3A%2F%2Funitedarchives.noip.me%2FPagodeEU%2FWHA_112_0849_PagEU_EN.jpg&type=IMAGE",
-    ],
-    id: "/2024909/photography_ProvidedCHO_United_Archives___WHA_02404781",
-    type: "IMAGE",
-    rights: ["http://creativecommons.org/licenses/by-sa/3.0/"],
-  },
-  thumbnails: [
-    "https://api.europeana.eu/thumbnail/v3/400/3bc0291af7adc6b013a4be826af1f794", // Portrait of a young Woman, with 'Puck' the Dog https://www.europeana.eu/en/item/90402/SK_A_1703
-    "https://api.europeana.eu/thumbnail/v3/400/3fa6a7d3f040cb177dc5b3f02d5570ab", // An eruption of Mount Etna at night https://www.europeana.eu/en/item/9200579/czyxv8m8
-    "https://api.europeana.eu/thumbnail/v3/400/822b6dce900b1ece45cb3c245e96849e", // Ansicht von Schloss Lohmen im Mondschein https://www.europeana.eu/en/item/15508/6863
-    "https://api.europeana.eu/thumbnail/v3/400/d392f7cf254c130962a1d1973a0768b3", // Winter Night in the Mountains https://www.europeana.eu/en/item/2063612/NO_280_003
-    "https://api.europeana.eu/thumbnail/v3/400/364d9429b3afa52add043c881c3908b6", // Group of Egrets https://www.europeana.eu/en/item/90402/RP_P_1999_550
-    "https://api.europeana.eu/thumbnail/v3/400/c05a1e113a4456407eb33c608e804068", // MG 007 Figure Of A Squatting Monkey https://www.europeana.eu/en/item/181/share3d_200
-    "https://api.europeana.eu/thumbnail/v3/400/6c5a64d12605a4a873a4781a9a689831", // In the Morning Sun (Village Courtyard) https://www.europeana.eu/en/item/07101/O_5179
-    "https://api.europeana.eu/thumbnail/v3/400/2cf841213010733ee7114e35e0a40995", // Sun over the Sea https://www.europeana.eu/en/item/2020903/KMS3853
-    "https://api.europeana.eu/thumbnail/v3/400/fb8c441eeaa8d346a62facea9ce4c8e8", // Letter-reading girl at the open window https://www.europeana.eu/en/item/669/item_55MVSCAD7QQUZWFSYEP5THIZIP5RM4OT
-    "https://api.europeana.eu/thumbnail/v3/400/9230c39c429d6a1da1684c5768bae50a", // Vrouw bekijkt bloemen in het veld https://www.europeana.eu/en/item/90402/RP_P_1896_A_19368_566
-    "https://api.europeana.eu/thumbnail/v3/400/01da00dce89dadcdfaa8f6890ccc49da", // Malerei | S2511/12-1333 Tidal Tales, Ropes and Snails  https://www.europeana.eu/en/item/2058611/_kimbl_d801476e_a436_4d34_a555_0a28b4211ead
   ],
 };

--- a/packages/apps/ds4ch/.storybook/sample-data.js
+++ b/packages/apps/ds4ch/.storybook/sample-data.js
@@ -1,0 +1,95 @@
+export default {
+  illustrations: {
+    events:
+      "https://images.ctfassets.net/i01duvb6kq77/3o9KQ2GWTLnEdPkF1wNyPe/5a7d9a9e8c3d314e530e0c275ef152dd/illustration_events.svg",
+    newsletter:
+      "https://images.ctfassets.net/i01duvb6kq77/1tvbbzdiq0sc0hBjbqlihZ/a60ff9eb7d24df0b0a1e54ae19d3c3d9/il_newsletter.svg",
+    curate:
+      "https://images.ctfassets.net/i01duvb6kq77/1DxiDhy46cX5eBheNYFdP7/42518b79959f2ea5cd270f9cffa022b2/homepage_A_v4_blackline.svg",
+    audience:
+      "https://images.ctfassets.net/i01duvb6kq77/B0VJ9of5sryy5n34hS93I/991133dbbc2dd0f48fd215e3aa1c3c75/Audience.svg",
+    support:
+      "https://images.ctfassets.net/i01duvb6kq77/KIMCBhGmlm90mxG8hldb1/8339d01737e9456cd10715b40f6c1925/feedback.svg",
+    search:
+      "https://images.ctfassets.net/i01duvb6kq77/JX06hL2kGk2mqCJLsoJUh/4d8bad1506779f0029c00f5f522e8e00/search.svg",
+  },
+  imagesWithAttribution: [
+    {
+      name: "Winter Landscape with Ice Skaters",
+      creator: "Hendrick Avercamp",
+      provider: "Rijksmuseum",
+      license: "http://creativecommons.org/publicdomain/mark/1.0/",
+      url: "http://data.europeana.eu/item/90402/SK_A_1718",
+      image: {
+        url: "https://images.ctfassets.net/i01duvb6kq77/3VbHNPpj2eyc4q0vO6EGON/a090ebe4e3cc4c570a6826647c58ed36/Winter_Landscape_with_Ice_Skaters",
+        description:
+          "painting, crowds of people ice skating among trees and houses.",
+        contentType: "image/jpeg",
+        width: 2928,
+        height: 1691,
+      },
+    },
+    {
+      name: "Northern Lights. Study from North Norway",
+      creator: "Anna Boberg",
+      provider: "Nationalmuseum Sweden",
+      license: "https://creativecommons.org/publicdomain/mark/1.0/",
+      url: "https://www.europeana.eu/en/item/2064116/Museu_ProvidedCHO_Nationalmuseum__Sweden_21327",
+      image: {
+        url: "https://images.ctfassets.net/i01duvb6kq77/61Q1XSrSqAtoWypDH4k1bY/b774eb32406e198f9ba5cdc8970e3e8f/Europeana.eu-2064116-Museu_ProvidedCHO_Nationalmuseum__Sweden_21327-b8dd190867b87b651c5907f7b33c6ad7.jpeg",
+        description:
+          "painting, blue and white rays of light shine from behind a mountain.",
+        contentType: "image/jpeg",
+        width: 1000,
+        height: 842,
+      },
+    },
+    {
+      name: "Eight plants, including two orchids, a crocus and some tulips: flowering stems. Coloured etching, c.1837.",
+      creator: "Undefined",
+      provider: "Wellcome Collection",
+      license: "http://creativecommons.org/licenses/by/4.0/",
+      url: "http://data.europeana.eu/item/9200579/hxf3z8ek",
+      image: {
+        url: "https://images.ctfassets.net/i01duvb6kq77/1l8m0GQ9crP6zvts5zWYos/0006db953cc9a8a08a064c141cd78777/feature_botanical-illustrations.jpg",
+        contentType: "image/jpeg",
+        description:
+          "colour illustration of a bunch of colourful flowers in yellow, red, orange",
+        width: 830,
+        height: 470,
+      },
+    },
+  ],
+  itemPreviewCardData: {
+    dataProvider: ["United Archives / WHA"],
+    dcCreatorLangAware: { en: ["United Archives / WHA"] },
+    dcDescriptionLangAware: {
+      de: [
+        `French, Coloured illustration, dated circa 1884, depicting a frilled-necked lizard (Chlamydosaurus kingii), also known as the frilled lizard,
+    frilled dragon or frilled agama, is a species of lizard which is found mainly in northern Australia and southern N…`,
+      ],
+    },
+    dcTitleLangAware: {
+      en: ["illustration, circa 1884,depicting a frilled-necked lizard"],
+    },
+    edmPreview: [
+      "https://api.europeana.eu/thumbnail/v2/url.json?uri=http%3A%2F%2Funitedarchives.noip.me%2FPagodeEU%2FWHA_112_0849_PagEU_EN.jpg&type=IMAGE",
+    ],
+    id: "/2024909/photography_ProvidedCHO_United_Archives___WHA_02404781",
+    type: "IMAGE",
+    rights: ["http://creativecommons.org/licenses/by-sa/3.0/"],
+  },
+  thumbnails: [
+    "https://api.europeana.eu/thumbnail/v3/400/3bc0291af7adc6b013a4be826af1f794", // Portrait of a young Woman, with 'Puck' the Dog https://www.europeana.eu/en/item/90402/SK_A_1703
+    "https://api.europeana.eu/thumbnail/v3/400/3fa6a7d3f040cb177dc5b3f02d5570ab", // An eruption of Mount Etna at night https://www.europeana.eu/en/item/9200579/czyxv8m8
+    "https://api.europeana.eu/thumbnail/v3/400/822b6dce900b1ece45cb3c245e96849e", // Ansicht von Schloss Lohmen im Mondschein https://www.europeana.eu/en/item/15508/6863
+    "https://api.europeana.eu/thumbnail/v3/400/d392f7cf254c130962a1d1973a0768b3", // Winter Night in the Mountains https://www.europeana.eu/en/item/2063612/NO_280_003
+    "https://api.europeana.eu/thumbnail/v3/400/364d9429b3afa52add043c881c3908b6", // Group of Egrets https://www.europeana.eu/en/item/90402/RP_P_1999_550
+    "https://api.europeana.eu/thumbnail/v3/400/c05a1e113a4456407eb33c608e804068", // MG 007 Figure Of A Squatting Monkey https://www.europeana.eu/en/item/181/share3d_200
+    "https://api.europeana.eu/thumbnail/v3/400/6c5a64d12605a4a873a4781a9a689831", // In the Morning Sun (Village Courtyard) https://www.europeana.eu/en/item/07101/O_5179
+    "https://api.europeana.eu/thumbnail/v3/400/2cf841213010733ee7114e35e0a40995", // Sun over the Sea https://www.europeana.eu/en/item/2020903/KMS3853
+    "https://api.europeana.eu/thumbnail/v3/400/fb8c441eeaa8d346a62facea9ce4c8e8", // Letter-reading girl at the open window https://www.europeana.eu/en/item/669/item_55MVSCAD7QQUZWFSYEP5THIZIP5RM4OT
+    "https://api.europeana.eu/thumbnail/v3/400/9230c39c429d6a1da1684c5768bae50a", // Vrouw bekijkt bloemen in het veld https://www.europeana.eu/en/item/90402/RP_P_1896_A_19368_566
+    "https://api.europeana.eu/thumbnail/v3/400/01da00dce89dadcdfaa8f6890ccc49da", // Malerei | S2511/12-1333 Tidal Tales, Ropes and Snails  https://www.europeana.eu/en/item/2058611/_kimbl_d801476e_a436_4d34_a555_0a28b4211ead
+  ],
+};

--- a/packages/apps/ds4ch/assets/scss/main.scss
+++ b/packages/apps/ds4ch/assets/scss/main.scss
@@ -6,6 +6,7 @@
 @import "@europeana/style/scss/default";
 @import "@europeana/style/scss/grid";
 @import "@europeana/style/scss/icons";
+@import "@europeana/style/scss/licenses";
 
 @import "fonts";
 @import "variables";

--- a/packages/apps/ds4ch/i18n/locales/en.json
+++ b/packages/apps/ds4ch/i18n/locales/en.json
@@ -1,4 +1,10 @@
 {
+  "attribution": {
+    "creator": "Creator:",
+    "institution": "Institution:",
+    "show": "Show attribution",
+    "title": "Title:"
+  },
   "footer": {
     "about": "About the data space",
     "accessibility": "Accessibility",

--- a/packages/apps/ds4ch/tests/unit.setup.ts
+++ b/packages/apps/ds4ch/tests/unit.setup.ts
@@ -1,3 +1,4 @@
 import { config } from "@vue/test-utils";
 
 config.global.mocks.$t = (key: string) => key;
+config.global.stubs["i18n-t"] = true;

--- a/packages/apps/ds4ch/vitest.config.ts
+++ b/packages/apps/ds4ch/vitest.config.ts
@@ -1,12 +1,9 @@
 import { defineVitestConfig } from "@nuxt/test-utils/config";
-import { coverageConfigDefaults } from "vitest/config";
+
 import { fileURLToPath } from "node:url";
 
 export default defineVitestConfig({
   test: {
-    coverage: {
-      exclude: [...coverageConfigDefaults.exclude, "nuxt.config.ts"],
-    },
     extends: true,
     setupFiles: ["tests/unit.setup.ts"],
     environment: "nuxt",

--- a/packages/base/components/Generic/RightsStatement.spec.js
+++ b/packages/base/components/Generic/RightsStatement.spec.js
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+import { shallowMount } from "@vue/test-utils";
+import RightsStatement from "./RightsStatement.vue";
+
+const factory = (props) =>
+  shallowMount(RightsStatement, {
+    props,
+  });
+
+const statements = [
+  {
+    label: "CC BY-NC-ND",
+    urls: ["http://creativecommons.org/licenses/by-nc-nd/4.0/"],
+    classes: ["cc", "by", "nc", "nd"],
+  },
+  {
+    label: "CC BY-NC-SA",
+    urls: ["http://creativecommons.org/licenses/by-nc-sa/4.0/"],
+    classes: ["cc", "by", "nc", "sa"],
+  },
+  {
+    label: "CC BY-NC",
+    urls: ["http://creativecommons.org/licenses/by-nc/4.0/"],
+    classes: ["cc", "by", "nc"],
+  },
+  {
+    label: "CC BY-ND",
+    urls: ["http://creativecommons.org/licenses/by-nd/4.0/"],
+    classes: ["cc", "by", "nd"],
+  },
+  {
+    label: "CC BY-SA",
+    urls: ["http://creativecommons.org/licenses/by-sa/4.0/"],
+    classes: ["cc", "by", "sa"],
+  },
+  {
+    label: "CC BY",
+    urls: ["http://creativecommons.org/licenses/by/4.0/"],
+    classes: ["cc", "by"],
+  },
+  {
+    label: "CC0",
+    urls: ["http://creativecommons.org/publicdomain/zero/1.0/"],
+    classes: ["zero"],
+  },
+  {
+    label: "Copyright Not Evaluated",
+    urls: ["Copyright Not Evaluated"],
+    classes: [],
+  },
+  {
+    label: "Copyright Not Evaluated",
+    urls: [
+      "http://rightsstatements.org/page/CNE/1.0/",
+      "http://rightsstatements.org/vocab/CNE/1.0/",
+    ],
+    classes: ["rs-unknown"],
+  },
+  {
+    label: "In Copyright - Educational Use Permitted",
+    urls: [
+      "http://rightsstatements.org/page/InC-EDU/1.0/",
+      "http://rightsstatements.org/vocab/InC-EDU/1.0/",
+    ],
+    classes: ["rs-yes"],
+  },
+  {
+    label: "In Copyright - EU Orphan Work",
+    urls: [
+      "http://rightsstatements.org/page/InC-OW-EU/1.0/",
+      "http://rightsstatements.org/vocab/InC-OW-EU/1.0/",
+    ],
+    classes: ["rs-yes"],
+  },
+  {
+    label: "In Copyright",
+    urls: [
+      "http://rightsstatements.org/page/InC/1.0/",
+      "http://rightsstatements.org/vocab/InC/1.0/",
+    ],
+    classes: ["rs-yes"],
+  },
+  {
+    label: "No Copyright - Non-Commercial Use Only",
+    urls: [
+      "http://rightsstatements.org/page/NoC-NC/1.0/",
+      "http://rightsstatements.org/vocab/NoC-NC/1.0/",
+    ],
+    classes: ["rs-no"],
+  },
+  {
+    label: "No Copyright - Non-Commercial Use Only",
+    urls: ["http://www.europeana.eu/rights/out-of-copyright-non-commercial/"],
+    classes: ["rs-no"],
+  },
+  {
+    label: "No Copyright - Other Known Legal Restrictions",
+    urls: [
+      "http://rightsstatements.org/page/NoC-OKLR/1.0/",
+      "http://rightsstatements.org/vocab/NoC-OKLR/1.0/",
+    ],
+    classes: ["rs-no"],
+  },
+  {
+    label: "Public Domain",
+    urls: [
+      "http://creativecommons.org/publicdomain/mark/1.0/",
+      "http://creativecommons.org/licenses/publicdomain/mark/",
+    ],
+    classes: ["pd"],
+  },
+  {
+    label: "Rights Reserved - Free Access",
+    urls: ["http://www.europeana.eu/rights/rr-f/"],
+    classes: ["rr"],
+  },
+  {
+    label: "Rights Reserved - Paid Access",
+    urls: ["http://www.europeana.eu/rights/rr-p/"],
+    classes: ["rr"],
+  },
+  {
+    label: "Rights Reserved - Restricted Access",
+    urls: ["http://www.europeana.eu/rights/rr-r/"],
+    classes: ["rr"],
+  },
+  {
+    label: "Unknown copyright status",
+    urls: ["http://www.europeana.eu/rights/unknown/"],
+    classes: [],
+  },
+  { label: "Not a URL", urls: ["Not a URL"], classes: [] },
+  {
+    label: "https://example.org/",
+    urls: ["https://example.org/"],
+    classes: [],
+  },
+];
+
+describe("components/generic/RightsStatement", () => {
+  for (const statement of statements) {
+    for (const url of statement.urls) {
+      describe(`when URL is ${url}`, () => {
+        it(`is labelled "${statement.label}"`, () => {
+          const wrapper = factory({ rightsStatementUrl: url });
+
+          const rights = wrapper.find('[data-qa="rights statement"]');
+          expect(rights.text()).toBe(statement.label);
+        });
+
+        const iconCount = statement.classes.length;
+        it(`has ${iconCount} icon(s)`, () => {
+          const wrapper = factory({ rightsStatementUrl: url });
+
+          const icons = wrapper.findAll(
+            '[data-qa="rights statement"] .license',
+          );
+          expect(icons.length).toBe(iconCount);
+        });
+
+        for (const iconClassSuffix of statement.classes) {
+          const iconClass = `icon-license-${iconClassSuffix}`;
+          it(`has an icon with class "${iconClass}"`, () => {
+            const wrapper = factory({ rightsStatementUrl: url });
+
+            const icon = wrapper.find(
+              `[data-qa="rights statement"] .${iconClass}`,
+            );
+            expect(icon.isVisible()).toBe(true);
+          });
+        }
+      });
+    }
+  }
+});

--- a/packages/base/components/Generic/RightsStatement.stories.ts
+++ b/packages/base/components/Generic/RightsStatement.stories.ts
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@nuxtjs/storybook";
+
+import RightsStatement from "./RightsStatement.vue";
+
+const meta = {
+  component: RightsStatement,
+} satisfies Meta<typeof RightsStatement>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PublicDomain: Story = {
+  args: {
+    rightsStatementUrl: "http://creativecommons.org/publicdomain/mark/1.0/",
+  },
+};
+
+export const PublicDomainSimple: Story = {
+  args: {
+    rightsStatementUrl: "http://creativecommons.org/publicdomain/mark/1.0/",
+    variant: "simple",
+  },
+};
+
+export const CCBYSA: Story = {
+  args: {
+    rightsStatementUrl: "https://creativecommons.org/licenses/by-sa/4.0/",
+  },
+};
+
+export const CCBYSASimple: Story = {
+  args: {
+    rightsStatementUrl: "https://creativecommons.org/licenses/by-sa/4.0/",
+    variant: "simple",
+  },
+};

--- a/packages/base/components/Generic/RightsStatement.vue
+++ b/packages/base/components/Generic/RightsStatement.vue
@@ -1,0 +1,43 @@
+<script setup>
+import rightsNameAndIcon from "../../utils/rightsStatement.js";
+
+const props = defineProps({
+  rightsStatementUrl: {
+    type: String,
+    required: true,
+  },
+  /**
+   * Style variant to use
+   * @values icons, simple
+   */
+  variant: {
+    type: String,
+    default: "icons",
+  },
+});
+
+const rightsStatementData = computed(() =>
+  rightsNameAndIcon(props.rightsStatementUrl),
+);
+</script>
+
+<template>
+  <span
+    data-qa="rights statement"
+    class="license-label d-inline-flex align-items-center"
+    :class="{ 'text-uppercase': props.variant === 'simple' }"
+  >
+    <template v-if="props.variant === 'icons'">
+      <span
+        v-for="icon in rightsStatementData.iconClass"
+        :key="icon"
+        :class="icon"
+        class="license"
+      />
+    </template>
+    <span v-else class="icon-license" />
+    <span class="license-label-text">
+      {{ rightsStatementData.name }}
+    </span>
+  </span>
+</template>

--- a/packages/base/components/Image/ImageAttributionToggle.spec.js
+++ b/packages/base/components/Image/ImageAttributionToggle.spec.js
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { shallowMount } from "@vue/test-utils";
+import ImageAttributionToggle from "./ImageAttributionToggle.vue";
+
+const attribution = {
+  attribution: {
+    name: "Something",
+    creator: "Someone",
+    provider: "Somewhere",
+    license: "http://creativecommons.org/licenses/by-nd/4.0/",
+    url: "http://www.example.org/",
+  },
+};
+const factory = (props = attribution) =>
+  shallowMount(ImageAttributionToggle, {
+    attachTo: document.body,
+    props,
+  });
+
+describe("components/generic/ImageAttributionToggle", () => {
+  it("displays a toggle button", async () => {
+    const wrapper = factory();
+
+    const toggle = wrapper.find('[data-qa="toggle"]');
+
+    expect(toggle.isVisible()).toBe(true);
+  });
+  it("does not display the attribution", async () => {
+    const wrapper = factory();
+
+    const attribution = wrapper.find('[data-qa="attribution"]');
+
+    expect(attribution.exists()).toBe(false);
+  });
+
+  describe("when the toggle button is clicked", () => {
+    it("displays the attribution", async () => {
+      const wrapper = factory();
+
+      wrapper.find('[data-qa="toggle"]').trigger("click");
+      await wrapper.vm.$nextTick();
+      const attribution = wrapper.find('[data-qa="attribution"]');
+
+      expect(attribution.isVisible()).toBe(true);
+    });
+  });
+
+  describe("when the toggle button is moused over", () => {
+    const wrapper = factory();
+    it("displays the attribution", async () => {
+      wrapper.find('[data-qa="toggle"]').trigger("mouseover");
+      await wrapper.vm.$nextTick();
+      const attribution = wrapper.find('[data-qa="attribution"]');
+
+      expect(attribution.isVisible()).toBe(true);
+    });
+    describe("and the mouse leaves", () => {
+      it("removed the attribution and shows the toggle button", async () => {
+        wrapper.find('[data-qa="attribution toggle"]').trigger("mouseleave");
+        await wrapper.vm.$nextTick();
+        const attribution = wrapper.find('[data-qa="attribution"]');
+        const toggle = wrapper.find('[data-qa="toggle"]');
+
+        expect(attribution.exists()).toBe(false);
+        expect(toggle.isVisible()).toBe(true);
+      });
+    });
+  });
+
+  describe("when the toggle button is touched on touch device", () => {
+    it("displays the attribution", async () => {
+      const wrapper = factory();
+
+      wrapper.find('[data-qa="toggle"]').trigger("touchstart");
+      await wrapper.vm.$nextTick();
+      const attribution = wrapper.find('[data-qa="attribution"]');
+
+      expect(attribution.isVisible()).toBe(true);
+    });
+  });
+
+  describe("when the attribution is open", () => {
+    describe("and the escape key is pressed", () => {
+      it("closes the attribution and displays and sets focus on the toggle button", async () => {
+        const wrapper = factory();
+
+        wrapper.find('[data-qa="toggle"]').trigger("click");
+        await wrapper.vm.$nextTick();
+        wrapper
+          .find('[data-qa="attribution"]')
+          .trigger("keydown.escape.native");
+        await wrapper.vm.$nextTick();
+
+        const attribution = wrapper.find('[data-qa="attribution"]');
+        const toggleWithFocus = wrapper.find('[data-qa="toggle"]:focus');
+
+        expect(attribution.exists()).toBe(false);
+        expect(toggleWithFocus.isVisible()).toBe(true);
+      });
+    });
+    describe("and tabbing outside the attribution component", () => {
+      it("closes the attribution and shows the toggle button", async () => {
+        const wrapper = factory();
+
+        wrapper.find('[data-qa="toggle"]').trigger("click");
+        await wrapper.vm.$nextTick();
+        window.dispatchEvent(new KeyboardEvent("focusin"));
+        await wrapper.vm.$nextTick();
+        const attribution = wrapper.find('[data-qa="attribution"]');
+        const toggle = wrapper.find('[data-qa="toggle"]');
+
+        expect(attribution.exists()).toBe(false);
+        expect(toggle.isVisible()).toBe(true);
+      });
+    });
+  });
+
+  describe("computed", () => {
+    describe("rightsStatement", () => {
+      it("favours attribution.rightsStatement", () => {
+        const wrapper = factory({
+          attribution: {
+            ...attribution,
+            rightsStatement: "http://creativecommons.org/licenses/by-nd/4.0/",
+          },
+        });
+
+        const rightsStatement = wrapper.vm.rightsStatement;
+
+        expect(rightsStatement).toBe(
+          "http://creativecommons.org/licenses/by-nd/4.0/",
+        );
+      });
+
+      it("falls back to attribution.license", () => {
+        const wrapper = factory();
+
+        const rightsStatement = wrapper.vm.rightsStatement;
+
+        expect(rightsStatement).toBe(
+          "http://creativecommons.org/licenses/by-nd/4.0/",
+        );
+      });
+    });
+  });
+});

--- a/packages/base/components/Image/ImageAttributionToggle.stories.ts
+++ b/packages/base/components/Image/ImageAttributionToggle.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@nuxtjs/storybook";
+
+import ImageAttributionToggle from "./ImageAttributionToggle.vue";
+
+const meta = {
+  component: ImageAttributionToggle,
+} satisfies Meta<typeof ImageAttributionToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    attribution: {
+      name: "Something",
+      creator: "Someone",
+      provider: "Somewhere",
+      license: "http://creativecommons.org/licenses/by-nd/4.0/",
+      url: "http://www.example.org/",
+    },
+  },
+};

--- a/packages/base/components/Image/ImageAttributionToggle.vue
+++ b/packages/base/components/Image/ImageAttributionToggle.vue
@@ -1,0 +1,84 @@
+<script setup>
+import { onBeforeUnmount } from "vue";
+
+const props = defineProps({
+  attribution: {
+    type: Object,
+    default: null,
+  },
+});
+
+const keyboardNav = ref(false);
+const showCite = ref(false);
+const rightsStatement = computed(() => {
+  return props.attribution?.rightsStatement || props.attribution?.license;
+});
+watch(showCite, (newVal) => {
+  if (newVal) {
+    window.addEventListener("focusin", handleWindowFocusin);
+  } else {
+    window.removeEventListener("focusin", handleWindowFocusin);
+  }
+});
+onBeforeUnmount(() => {
+  window.removeEventListener("focusin", handleWindowFocusin);
+});
+
+const toggle = useTemplateRef("toggle");
+const attributionToggle = useTemplateRef("attributiontoggle");
+
+const toggleCite = () => {
+  showCite.value = !showCite.value;
+};
+const handleCiteAttributionKeydownEscape = async () => {
+  resetKeyboardNav();
+  toggleCite();
+  await nextTick(() => {
+    toggle.value.focus();
+  });
+};
+const handleWindowFocusin = (event) => {
+  // focus has changed, toggle the citation if not to a child element
+  if (!attributionToggle.value?.contains(event.target)) {
+    toggleCite();
+    resetKeyboardNav();
+  }
+};
+const resetKeyboardNav = () => {
+  keyboardNav.value = false;
+};
+</script>
+
+<template>
+  <figcaption
+    ref="attributiontoggle"
+    class="background-attribution"
+    data-qa="attribution toggle"
+    @mouseleave="toggleCite"
+  >
+    <button
+      v-show="!showCite"
+      ref="toggle"
+      :aria-expanded="showCite ? 'true' : 'false'"
+      class="button-icon-only icon-info bg-transparent border-0"
+      data-qa="toggle"
+      :aria-label="$t('attribution.show')"
+      @click="toggleCite"
+      @mouseover="toggleCite"
+      @touchstart="toggleCite"
+      @keydown="keyboardNav = true"
+    />
+    <ImageCiteAttribution
+      v-if="showCite"
+      :name="attribution ? attribution.name : null"
+      :creator="attribution ? attribution.creator : null"
+      :provider="attribution ? attribution.provider : null"
+      :rights-statement="rightsStatement"
+      :url="attribution ? attribution.url : null"
+      :set-focus="keyboardNav"
+      extended
+      data-qa="attribution"
+      @keydown.escape="handleCiteAttributionKeydownEscape"
+    />
+  </figcaption>
+</template>

--- a/packages/base/components/Image/ImageCiteAttribution.spec.js
+++ b/packages/base/components/Image/ImageCiteAttribution.spec.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import ImageCiteAttribution from "./ImageCiteAttribution.vue";
+
+const requiredProps = {
+  rightsStatement: "http://creativecommons.org/publicdomain/mark/1.0/",
+};
+
+const url = "http://www.example.org/something";
+
+const factory = (props) =>
+  mount(ImageCiteAttribution, {
+    attachTo: document.body,
+    props: {
+      ...requiredProps,
+      ...props,
+    },
+    global: { stubs: ["RouterLink"] },
+  });
+
+describe("components/generic/ImageCiteAttribution", () => {
+  it("has a link", () => {
+    const url = "http://www.example.org/something";
+    const wrapper = factory({ url });
+
+    const link = wrapper.find("cite a");
+    expect(link.attributes().href).toBe(url);
+  });
+
+  it("has an attribution", () => {
+    const creator = "Johannes Vermeer";
+    const wrapper = factory({ creator, extended: true, url });
+
+    const attribution = wrapper.find("cite a");
+    expect(attribution.text()).toContain(creator);
+  });
+
+  it("has a rights statement", () => {
+    const wrapper = factory({
+      rightsStatement: "http://rightsstatements.org/vocab/InC/1.0/",
+      url,
+    });
+
+    const rights = wrapper.find("cite a span");
+    expect(rights.text()).toContain("In Copyright");
+  });
+
+  describe(".linkText", () => {
+    it("is concatenates name, creator and provider", () => {
+      const name = "Something";
+      const creator = "Someone";
+      const provider = "Somewhere";
+      const wrapper = factory({ name, creator, provider });
+
+      expect(wrapper.vm.linkText).toBe("Something, Someone, Somewhere");
+    });
+
+    it("omits empty fields", () => {
+      const name = "Something";
+      const provider = "Somewhere";
+      const wrapper = factory({ name, provider });
+
+      expect(wrapper.vm.linkText).toBe("Something, Somewhere");
+    });
+  });
+
+  describe("when extended through keyboard navigation", () => {
+    it("sets focus on the first link", () => {
+      const wrapper = factory({
+        ...requiredProps,
+        extended: true,
+        setFocus: true,
+      });
+
+      const link = wrapper.find("cite a:focus");
+      expect(link.exists()).toBe(true);
+    });
+  });
+});

--- a/packages/base/components/Image/ImageCiteAttribution.stories.ts
+++ b/packages/base/components/Image/ImageCiteAttribution.stories.ts
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@nuxtjs/storybook";
+
+import ImageCiteAttribution from "./ImageCiteAttribution.vue";
+
+const meta = {
+  component: ImageCiteAttribution,
+} satisfies Meta<typeof ImageCiteAttribution>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    name: "The Milkmaid",
+    creator: "Johannes Vermeer",
+    provider: "Rijksmuseum",
+    rightsStatement: "http://creativecommons.org/publicdomain/mark/1.0/",
+    url: "https://www.example.eu/milkmaid",
+    extended: true,
+  },
+};
+
+export const Minimal: Story = {
+  args: {
+    rightsStatement: "http://creativecommons.org/publicdomain/mark/1.0/",
+  },
+};
+
+export const NoUrl: Story = {
+  args: {
+    name: "The Milkmaid",
+    creator: "Johannes Vermeer",
+    provider: "Rijksmuseum",
+    rightsStatement: "http://creativecommons.org/publicdomain/mark/1.0/",
+  },
+};
+
+export const NoExtended: Story = {
+  args: {
+    name: "The Milkmaid",
+    creator: "Johannes Vermeer",
+    provider: "Rijksmuseum",
+    rightsStatement: "http://creativecommons.org/publicdomain/mark/1.0/",
+    url: "https://www.example.eu/milkmaid",
+  },
+};

--- a/packages/base/components/Image/ImageCiteAttribution.stories.ts
+++ b/packages/base/components/Image/ImageCiteAttribution.stories.ts
@@ -32,6 +32,7 @@ export const NoUrl: Story = {
     creator: "Johannes Vermeer",
     provider: "Rijksmuseum",
     rightsStatement: "http://creativecommons.org/publicdomain/mark/1.0/",
+    extended: true,
   },
 };
 

--- a/packages/base/components/Image/ImageCiteAttribution.vue
+++ b/packages/base/components/Image/ImageCiteAttribution.vue
@@ -1,0 +1,199 @@
+<script setup>
+// explicit import needed for dynamic components: https://nuxt.com/docs/guide/directory-structure/components#dynamic-components
+import { GenericSmartLink } from "#components";
+
+const props = defineProps({
+  /**
+   * Name of the cited resource
+   */
+  name: {
+    type: String,
+    default: null,
+  },
+  /**
+   * Creator of the cited resource
+   */
+  creator: {
+    type: String,
+    default: null,
+  },
+  /**
+   * Provider of the cited resource
+   */
+  provider: {
+    type: String,
+    default: null,
+  },
+  /**
+   * Rights statement URL of the cited resource
+   */
+  rightsStatement: {
+    type: String,
+    required: true,
+  },
+  /**
+   * URL of the cited resource
+   */
+  url: {
+    type: String,
+    default: null,
+  },
+  /**
+   * If `true`, use the extended format
+   */
+  extended: {
+    type: Boolean,
+    default: false,
+  },
+  /**
+   * If `true`, focus the first link when mounted
+   */
+  setFocus: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const linkText = computed(() =>
+  [props.name, props.creator, props.provider].filter(Boolean).join(", "),
+);
+
+const cite = useTemplateRef("cite");
+
+onMounted(() => {
+  if (props.extended && props.setFocus) {
+    cite.value.getElementsByTagName("a")[0]?.focus();
+  }
+});
+</script>
+<template>
+  <cite v-if="props.extended" ref="cite" class="cite-attribution">
+    <p v-if="props.name">
+      {{ $t("attribution.title") }}
+      <GenericSmartLink v-if="props.url" :destination="props.url">
+        {{ props.name }}
+      </GenericSmartLink>
+      <span v-else> {{ props.name }} </span>
+    </p>
+    <p v-if="props.creator">
+      {{ $t("attribution.creator") }}
+      <GenericSmartLink v-if="props.url" :destination="props.url">
+        {{ props.creator }}
+      </GenericSmartLink>
+      <span v-else> {{ props.creator }} </span>
+    </p>
+    <p v-if="props.provider">
+      {{ $t("attribution.institution") }}
+      <GenericSmartLink v-if="props.url" :destination="props.url">
+        {{ props.provider }}
+      </GenericSmartLink>
+      <span v-else> {{ props.provider }} </span>
+    </p>
+    <p>
+      <GenericSmartLink
+        :destination="props.rightsStatement"
+        class="attribution"
+      >
+        <GenericRightsStatement
+          v-if="props.rightsStatement"
+          :rights-statement-url="props.rightsStatement"
+        />
+      </GenericSmartLink>
+    </p>
+  </cite>
+  <cite v-else>
+    <component
+      :is="props.url ? GenericSmartLink : 'span'"
+      :destination="props.url"
+      class="attribution"
+    >
+      {{ linkText }}
+      <!-- TODO: shouldn't this have its own link to the rightsStatement? -->
+      <GenericRightsStatement
+        v-if="props.rightsStatement"
+        :rights-statement-url="props.rightsStatement"
+      />
+    </component>
+  </cite>
+</template>
+<style lang="scss" scoped>
+@import "@europeana/style/scss/variables";
+
+// TODO: Remove duplicate styles from @europeana/style/scss/default
+cite {
+  background: $white;
+  border: none;
+  border-radius: 0.25rem;
+  bottom: 0.5rem;
+  box-shadow: $boxshadow-small;
+  display: inline;
+  font-size: 0.75rem;
+  left: initial;
+  margin: 0;
+  max-width: 75%;
+  padding: 0.75rem;
+  position: absolute;
+  right: 0.5rem;
+  text-align: left;
+
+  @at-root .xxl-page & {
+    @media (min-width: $bp-4k) {
+      border-radius: calc(1.5 * 0.25rem);
+      bottom: 0.75rem;
+      font-size: calc(1.5 * 0.75rem);
+      padding: calc(1.5 * 0.75rem);
+      right: 0.75rem;
+    }
+  }
+
+  &.cite-attribution {
+    a {
+      text-decoration: none;
+    }
+  }
+
+  p {
+    color: $darkgrey;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 0.25rem;
+
+    @at-root .xxl-page & {
+      @media (min-width: $bp-4k) {
+        margin-bottom: calc(1.5 * 0.25rem);
+      }
+    }
+  }
+
+  .icon-external-link {
+    line-height: 1.5;
+  }
+
+  .attribution {
+    margin-top: 0.5rem;
+
+    @at-root .xxl-page & {
+      @media (min-width: $bp-4k) {
+        margin-top: 0.75rem;
+      }
+    }
+
+    > span {
+      margin-left: 0;
+
+      .license {
+        font-size: $font-size-small;
+        margin-top: -0.1rem;
+
+        @at-root .xxl-page & {
+          @media (min-width: $bp-4k) {
+            font-size: $font-size-small-4k;
+            margin-top: -0.15rem;
+          }
+        }
+      }
+    }
+  }
+}
+</style>

--- a/packages/base/components/Image/ImageEagerOrLazy.spec.js
+++ b/packages/base/components/Image/ImageEagerOrLazy.spec.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { shallowMount } from "@vue/test-utils";
+import ImageEagerOrLazy from "./ImageEagerOrLazy.vue";
+
+const factory = (props) =>
+  shallowMount(ImageEagerOrLazy, {
+    props: {
+      height: 200,
+      width: 200,
+      src: "https://www.example.eu/image.webp",
+      ...props,
+    },
+  });
+
+describe("ImageEagerOrLazy", () => {
+  it("renders an image with alt attribute", () => {
+    const altText = "alternative text";
+    const wrapper = factory({ alt: altText });
+    const img = wrapper.find("img");
+
+    expect(img.exists()).toBe(true);
+    expect(img.attributes("alt")).toBe(altText);
+  });
+  describe("when lazy is set to true", () => {
+    it("lazy loads the image", () => {
+      const wrapper = factory({ lazy: true });
+      const img = wrapper.find("img");
+
+      expect(img.attributes("loading")).toBe("lazy");
+    });
+  });
+  describe("when lazy is set to false", () => {
+    it("eager loads the image", () => {
+      const wrapper = factory({ lazy: false });
+      const img = wrapper.find("img");
+
+      expect(img.attributes("loading")).toBe("eager");
+    });
+  });
+});

--- a/packages/base/components/Image/ImageEagerOrLazy.vue
+++ b/packages/base/components/Image/ImageEagerOrLazy.vue
@@ -1,0 +1,50 @@
+<!-- TODO: test if native lazy loading is handled sufficiently by modern browsers. Else, use a library or IntersectionObserver -->
+<script setup>
+const props = defineProps({
+  alt: {
+    type: String,
+    default: null,
+  },
+
+  height: {
+    type: [Number, String],
+    required: true,
+  },
+
+  lazy: {
+    type: Boolean,
+    default: false,
+  },
+
+  sizes: {
+    type: String,
+    default: null,
+  },
+
+  src: {
+    type: String,
+    required: true,
+  },
+
+  srcset: {
+    type: String,
+    default: null,
+  },
+
+  width: {
+    type: [Number, String],
+    required: true,
+  },
+});
+</script>
+<template>
+  <img
+    :alt="props.alt"
+    :src="props.src"
+    :srcset="props.srcset"
+    :sizes="props.sizes"
+    :width="props.width"
+    :height="props.height"
+    :loading="props.lazy ? 'lazy' : 'eager'"
+  />
+</template>

--- a/packages/base/components/Image/ImageOptimised.spec.js
+++ b/packages/base/components/Image/ImageOptimised.spec.js
@@ -1,0 +1,206 @@
+import { describe, it, expect } from "vitest";
+import { shallowMount } from "@vue/test-utils";
+import ImageOptimised from "./ImageOptimised.vue";
+
+const factory = (props) =>
+  shallowMount(ImageOptimised, {
+    props: {
+      width: 2000,
+      height: 1250,
+      ...props,
+    },
+  });
+
+describe("components/image/ImageOptimised", () => {
+  describe("template", () => {
+    it("uses a lazy loading image by default", () => {
+      const wrapper = factory({
+        src: "https://www.example.org/image.jpeg",
+        width: 2000,
+        height: 1250,
+      });
+
+      const lazyImage = wrapper.find("image-eager-or-lazy-stub");
+
+      expect(lazyImage.attributes("lazy")).toBe("true");
+    });
+
+    describe("when lazy is set to false", () => {
+      it("uses a non-lazy loading image", () => {
+        const wrapper = factory({
+          src: "https://www.example.org/image.jpeg",
+          width: 2000,
+          height: 1250,
+          lazy: false,
+        });
+
+        const image = wrapper.find("image-eager-or-lazy-stub");
+
+        expect(image.attributes("lazy")).toBe("false");
+      });
+    });
+
+    describe("when image is contentful asset with image crop presets", () => {
+      const src = "https://images.ctfassets.net/asset";
+      const contentfulImageCropPresets = {
+        small: { w: 576, h: 896, fit: "fill" },
+        medium: { w: 768, h: 1080, fit: "fill" },
+      };
+      const pictureSourceMediaResolutions = [1, 2];
+
+      it("renders an image component for the first resolution, with responsive srcset", () => {
+        const wrapper = factory({
+          contentfulImageCropPresets,
+          height: 1250,
+          pictureSourceMediaResolutions,
+          src,
+          width: 2000,
+        });
+
+        const img = wrapper.find("picture image-eager-or-lazy-stub");
+
+        expect(img.attributes("src")).toBe(
+          "https://images.ctfassets.net/asset?q=80&fm=webp",
+        );
+        expect(img.attributes("srcset")).toBe(
+          "https://images.ctfassets.net/asset?w=576&h=896&fit=fill&q=80&fm=webp 576w,https://images.ctfassets.net/asset?w=768&h=1080&fit=fill&q=80&fm=webp 768w",
+        );
+      });
+
+      it("renders a source element for other resolutions, with responsive srcset", () => {
+        const wrapper = factory({
+          contentfulImageCropPresets,
+          height: 1250,
+          pictureSourceMediaResolutions,
+          src,
+          width: 2000,
+        });
+
+        const source = wrapper.find("picture source");
+
+        expect(source.attributes("srcset")).toBe(
+          "https://images.ctfassets.net/asset?w=1152&h=1792&fit=fill&q=80&fm=webp 1152w,https://images.ctfassets.net/asset?w=1536&h=2160&fit=fill&q=80&fm=webp 1536w",
+        );
+        expect(source.attributes("media")).toBe("(resolution: 2x)");
+      });
+    });
+  });
+
+  describe("aspectRatio", () => {
+    it("equals width / height", () => {
+      const wrapper = factory({
+        src: "https://www.example.org/image.jpeg",
+        width: 2000,
+        height: 1250,
+      });
+
+      const aspectRatio = wrapper.vm.aspectRatio;
+
+      expect(aspectRatio).toBe(1.6);
+    });
+  });
+
+  describe("optimisedWidth", () => {
+    describe("with no maxWidth", () => {
+      it("is unaltered image width", () => {
+        const wrapper = factory({
+          src: "https://www.example.org/image.jpeg",
+          width: 2000,
+          height: 1250,
+        });
+
+        const optimisedWidth = wrapper.vm.optimisedWidth;
+
+        expect(optimisedWidth).toBe(2000);
+      });
+    });
+
+    describe("when width is less than maxWidth", () => {
+      it("is unaltered image width", () => {
+        const wrapper = factory({
+          src: "https://www.example.org/image.jpeg",
+          width: 2000,
+          height: 1250,
+          maxWidth: 2500,
+        });
+
+        const optimisedWidth = wrapper.vm.optimisedWidth;
+
+        expect(optimisedWidth).toBe(2000);
+      });
+    });
+
+    describe("when width exceeds maxWidth", () => {
+      it("is maxWidth", () => {
+        const wrapper = factory({
+          src: "https://www.example.org/image.jpeg",
+          width: 2000,
+          height: 1250,
+          maxWidth: 1500,
+        });
+
+        const optimisedWidth = wrapper.vm.optimisedWidth;
+
+        expect(optimisedWidth).toBe(1500);
+      });
+    });
+  });
+
+  describe("optimisedHeight", () => {
+    it("is based on optimisedWidth, respecting aspect ratio", () => {
+      const wrapper = factory({
+        src: "https://www.example.org/image.jpeg",
+        width: 2000,
+        height: 1250,
+        maxWidth: 1500,
+      });
+
+      const optimisedHeight = wrapper.vm.optimisedHeight;
+
+      expect(optimisedHeight).toBe(938);
+    });
+  });
+
+  describe("optimisedSrc", () => {
+    describe("when src is not for Contentful image", () => {
+      const src = "https://www.example.org/image.jpeg";
+
+      it("uses src unaltered", () => {
+        const wrapper = factory({
+          src,
+          width: 2000,
+          height: 1250,
+        });
+
+        const optimisedSrc = wrapper.vm.optimisedImageSrc;
+
+        expect(optimisedSrc).toBe(src);
+      });
+    });
+
+    describe("when src is for Contentful image", () => {
+      const src = "https://images.ctfassets.net/asset";
+      describe('and contentType is "image/jpeg"', () => {
+        const contentType = "image/jpeg";
+
+        const propsData = {
+          src,
+          contentType,
+          width: 2000,
+          height: 1250,
+          maxWidth: 1500,
+        };
+
+        it("is optimised via Contentful Images API", () => {
+          const wrapper = factory(propsData);
+
+          const optimisedSrc = wrapper.vm.optimisedImageSrc;
+
+          expect(optimisedSrc).toBe(
+            "https://images.ctfassets.net/asset?w=1500&q=80&fm=webp",
+          );
+        });
+      });
+    });
+  });
+});

--- a/packages/base/components/Image/ImageOptimised.vue
+++ b/packages/base/components/Image/ImageOptimised.vue
@@ -72,7 +72,6 @@ const optimisedWidth = computed(() => {
 const optimisedHeight = computed(() => {
   return Math.round(optimisedWidth.value / aspectRatio.value);
 });
-console.log(optimisedWidth.value, optimisedHeight.value, aspectRatio.value);
 
 const optimisedImageSrc = computed(() => {
   return optimisedSrc(

--- a/packages/base/components/Image/ImageOptimised.vue
+++ b/packages/base/components/Image/ImageOptimised.vue
@@ -1,0 +1,141 @@
+<script setup>
+import {
+  isValidUrl,
+  optimisedSrc,
+  responsiveImageSrcset,
+} from "../../utils/contentful/assets.js";
+
+const props = defineProps({
+  src: {
+    type: String,
+    required: true,
+  },
+  width: {
+    type: [Number, String],
+    required: true,
+  },
+  height: {
+    type: [Number, String],
+    required: true,
+  },
+  alt: {
+    type: String,
+    default: "",
+  },
+  contentType: {
+    // TODO: required?
+    type: String,
+    default: null,
+  },
+  quality: {
+    type: Number,
+    default: 80,
+  },
+  maxWidth: {
+    type: Number,
+    default: null,
+  },
+  lazy: {
+    type: Boolean,
+    default: true,
+  },
+  contentfulImageCropPresets: {
+    type: Object,
+    default: null,
+  },
+  contentfulImageDisplayProfile: {
+    type: Object,
+    default: null,
+  },
+  pictureSourceMediaResolutions: {
+    type: Array,
+    default: () => [1],
+  },
+  imageSizes: {
+    type: String,
+    default: null,
+  },
+});
+
+const isContentfulAsset = isValidUrl(props.src) || false;
+
+const aspectRatio = computed(() => {
+  return props.width / props.height;
+});
+
+const optimisedWidth = computed(() => {
+  return props.maxWidth === null || props.width <= props.maxWidth
+    ? props.width
+    : props.maxWidth;
+});
+
+const optimisedHeight = computed(() => {
+  return Math.round(optimisedWidth.value / aspectRatio.value);
+});
+console.log(optimisedWidth.value, optimisedHeight.value, aspectRatio.value);
+
+const optimisedImageSrc = computed(() => {
+  return optimisedSrc(
+    { url: props.src, contentType: props.contentType },
+    { w: props.maxWidth, q: props.quality },
+  );
+});
+
+const responsiveImageSrcsets = computed(() => {
+  if (!isContentfulAsset || !props.contentfulImageCropPresets) {
+    return null;
+  }
+
+  return props.pictureSourceMediaResolutions.map((resolution) => {
+    const resolutionSizes = Object.keys(
+      props.contentfulImageCropPresets,
+    ).reduce((memo, key) => {
+      memo[key] = {
+        ...props.contentfulImageCropPresets[key],
+        w: props.contentfulImageCropPresets[key].w * resolution,
+        h: props.contentfulImageCropPresets[key].h * resolution,
+        q: props.quality,
+      };
+      return memo;
+    }, {});
+
+    return responsiveImageSrcset(
+      { contentType: props.contentType, url: props.src },
+      resolutionSizes,
+      props.contentfulImageDisplayProfile,
+    );
+  });
+});
+</script>
+
+<template>
+  <picture v-if="responsiveImageSrcsets">
+    <template v-for="(srcset, index) in responsiveImageSrcsets">
+      <source
+        v-if="index > 0"
+        :key="index"
+        :srcset="srcset"
+        :sizes="props.imageSizes"
+        :media="`(resolution: ${index + 1}x)`"
+      />
+    </template>
+    <ImageEagerOrLazy
+      :alt="alt"
+      :height="optimisedHeight"
+      :lazy="props.lazy"
+      :sizes="props.imageSizes"
+      :src="optimisedImageSrc"
+      :srcset="responsiveImageSrcsets[0]"
+      :width="optimisedWidth"
+    />
+  </picture>
+  <ImageEagerOrLazy
+    v-else
+    :alt="alt"
+    :height="optimisedHeight"
+    :lazy="props.lazy"
+    :sizes="props.imageSizes"
+    :src="optimisedImageSrc"
+    :width="optimisedWidth"
+  />
+</template>

--- a/packages/base/components/Image/ImageWithAttribution.spec.js
+++ b/packages/base/components/Image/ImageWithAttribution.spec.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { shallowMount } from "@vue/test-utils";
+import ImageWithAttribution from "./ImageWithAttribution.vue";
+
+const propsData = {
+  src: "https://www.example.org/image.jpeg",
+  attribution: {
+    name: "Something",
+    creator: "Someone",
+    provider: "Somewhere",
+    rightsStatement: "http://creativecommons.org/licenses/by-nd/4.0/",
+    url: "http://www.example.org/",
+  },
+};
+
+const factory = () =>
+  shallowMount(ImageWithAttribution, {
+    propsData,
+  });
+
+describe("components/image/ImageWithAttribution", () => {
+  it("renders the image", () => {
+    const wrapper = factory();
+    const image = wrapper.find('figure [data-qa="image"]');
+    expect(image.attributes().src).toBe(propsData.src);
+  });
+});

--- a/packages/base/components/Image/ImageWithAttribution.stories.ts
+++ b/packages/base/components/Image/ImageWithAttribution.stories.ts
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@nuxtjs/storybook";
+
+import ImageWithAttribution from "./ImageWithAttribution.vue";
+import sampleData from "../../../apps/ds4ch/.storybook/sample-data.js";
+
+const meta = {
+  component: ImageWithAttribution,
+} satisfies Meta<typeof ImageWithAttribution>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    src: sampleData.imagesWithAttribution[0].image.url,
+    width: sampleData.imagesWithAttribution[0].image.width,
+    height: "auto",
+    alt: sampleData.imagesWithAttribution[0].image.description,
+    contentType: sampleData.imagesWithAttribution[0].image.contentType,
+    attribution: sampleData.imagesWithAttribution[0],
+  },
+};
+
+export const CroppedFullViewport: Story = {
+  args: {
+    src: sampleData.imagesWithAttribution[0].image.url,
+    width: "auto",
+    height: "auto",
+    alt: sampleData.imagesWithAttribution[0].image.description,
+    contentType: sampleData.imagesWithAttribution[0].image.contentType,
+    attribution: sampleData.imagesWithAttribution[0],
+    maxWidth: null,
+    contentfulImageCropPresets: {
+      small: { w: 576, h: 896, fit: "fill" },
+      medium: { w: 768, h: 1080, fit: "fill" },
+      large: { w: 992, h: 1080, fit: "fill" },
+      xl: { w: 1200, h: 1080, fit: "fill" },
+      xxl: { w: 1400, h: 1080, fit: "fill" },
+      xxxl: { w: 1880, h: 1080, fit: "fill" },
+      wqhd: { w: 2520, h: 1440, fit: "fill" },
+      "4k": { w: 3020, h: 1440, fit: "fill" },
+      "4k+": { w: 3840, h: 2160, fit: "fill" },
+    },
+  },
+};

--- a/packages/base/components/Image/ImageWithAttribution.vue
+++ b/packages/base/components/Image/ImageWithAttribution.vue
@@ -1,0 +1,73 @@
+<script setup>
+const props = defineProps({
+  src: {
+    type: String,
+    required: true,
+  },
+  width: {
+    type: [Number, String],
+    default: 550,
+  },
+  height: {
+    type: [Number, String],
+    default: 790,
+  },
+  alt: {
+    type: String,
+    default: "",
+  },
+  contentType: {
+    type: String,
+    default: null,
+  },
+  attribution: {
+    type: Object,
+    required: true,
+  },
+  maxWidth: {
+    type: [Number, null],
+    default: 1100,
+  },
+  contentfulImageDisplayProfile: {
+    type: Object,
+    default: null,
+  },
+  contentfulImageCropPresets: {
+    type: Object,
+    default: null,
+  },
+  pictureSourceMediaResolutions: {
+    type: Array,
+    default: () => [1],
+  },
+  imageSizes: {
+    type: String,
+    default: null,
+  },
+  lazy: {
+    type: Boolean,
+    default: true,
+  },
+});
+</script>
+<template>
+  <figure>
+    <ImageOptimised
+      v-if="props.src"
+      ref="image"
+      :src="props.src"
+      :width="props.width"
+      :height="props.height"
+      :alt="props.alt"
+      :content-type="props.contentType"
+      :max-width="props.maxWidth"
+      data-qa="image"
+      :image-sizes="props.imageSizes"
+      :contentful-image-crop-presets="props.contentfulImageCropPresets"
+      :contentful-image-display-profile="props.contentfulImageDisplayProfile"
+      :picture-source-media-resolutions="props.pictureSourceMediaResolutions"
+      :lazy="props.lazy"
+    />
+    <ImageAttributionToggle :attribution="props.attribution" />
+  </figure>
+</template>

--- a/packages/base/utils/contentful/assets.js
+++ b/packages/base/utils/contentful/assets.js
@@ -1,0 +1,102 @@
+const CONTENTFUL_IMAGES_ASSET_HOST = "images.ctfassets.net";
+const CONTENTFUL_IMAGES_PARAMS_FL_PROGRESSIVE = "progressive";
+const CONTENTFUL_IMAGES_PARAMS_FM_WEBP = "webp";
+const CONTENTFUL_IMAGES_PARAMS_FM_JPEG = "jpg";
+const MEDIA_TYPE_JPEG = "image/jpeg";
+const MEDIA_TYPE_SVG = "image/svg+xml";
+
+function imageApiParamsForImageDisplayProfile(profile) {
+  return {
+    ...(profile?.focus && { f: profile.focus }),
+    ...(profile?.fit && { fit: profile.fit }),
+    ...(profile?.quality && { q: profile.quality }),
+  };
+}
+
+export function imageDisplayProfileResponsiveSizes(sizes, profile) {
+  const deleteHeight = profile?.fit === "pad" && !profile?.crop;
+
+  return Object.keys(sizes).reduce((memo, size) => {
+    if (!profile || profile.sizes.includes(size)) {
+      memo[size] = { ...sizes[size] };
+
+      if (deleteHeight) {
+        delete memo[size].h;
+      }
+    }
+    return memo;
+  }, {});
+}
+
+export function isValidUrl(url) {
+  try {
+    return new URL(url).host === CONTENTFUL_IMAGES_ASSET_HOST;
+  } catch {
+    return false;
+  }
+}
+
+export function optimisedSrc(asset, options = {}, profile = {}) {
+  if (!isValidUrl(asset?.url)) {
+    return asset?.url || null;
+  }
+
+  const imageUrl = new URL(asset.url);
+  const profileParams = imageApiParamsForImageDisplayProfile(profile);
+
+  const params = { ...options, ...profileParams };
+
+  if (!params.fm && asset.contentType !== MEDIA_TYPE_SVG) {
+    params.fm = CONTENTFUL_IMAGES_PARAMS_FM_WEBP;
+    if (!params.q) {
+      params.q = 40;
+    }
+  } else if (asset.contentType === MEDIA_TYPE_JPEG) {
+    params.fm = CONTENTFUL_IMAGES_PARAMS_FM_JPEG;
+    params.fl = CONTENTFUL_IMAGES_PARAMS_FL_PROGRESSIVE;
+    if (!params.q) {
+      params.q = 80;
+    }
+  }
+
+  for (const key in params) {
+    if (params[key]) {
+      imageUrl.searchParams.set(key, params[key]);
+    }
+  }
+
+  return imageUrl.toString();
+}
+
+export function responsiveImageSrcset(image, sizes, profile) {
+  if (isValidUrl(image?.url) && sizes) {
+    const profileSizes = imageDisplayProfileResponsiveSizes(sizes, profile);
+
+    return Object.keys(profileSizes)
+      .map((size) => {
+        const url = optimisedSrc(image, profileSizes[size], profile);
+        return `${url} ${profileSizes[size].w}w`;
+      })
+      .join(",");
+  } else {
+    return null;
+  }
+}
+
+export function responsiveBackgroundImageCSSVars(image, sizes, profile) {
+  if (isValidUrl(image?.url) && sizes) {
+    const profileSizes = imageDisplayProfileResponsiveSizes(sizes, profile);
+
+    return Object.keys(profileSizes).reduce((memo, size) => {
+      const url = optimisedSrc(image, profileSizes[size], profile);
+      memo[`--bg-img-${size}`] = `url('${url}')`;
+      return memo;
+    }, {});
+  } else if (image?.url) {
+    return {
+      "--bg-img-small": `url('${image.url}')`,
+    };
+  } else {
+    return null;
+  }
+}

--- a/packages/base/utils/contentful/assets.spec.js
+++ b/packages/base/utils/contentful/assets.spec.js
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import * as assets from "@/utils/contentful/assets.js";
+
+const responsiveParams = {
+  small: { w: 245, h: 440, fit: "fill" },
+  medium: { w: 260, h: 420, fit: "fill" },
+  large: { w: 280, h: 400, fit: "fill" },
+  xl: { w: 300, h: 400, fit: "fill" },
+  xxl: { w: 320, h: 370, fit: "fill" },
+  xxxl: { w: 355, h: 345, fit: "fill" },
+  wqhd: { w: 510, h: 540, fit: "fill" },
+  "4k": { w: 700, h: 900, fit: "fill" },
+};
+
+describe("@/utils/contentful/assets.js", () => {
+  describe("isValidUrl", () => {
+    it("is `true` for URLs on host images.ctfassets.net", () => {
+      const src = "https://images.ctfassets.net/asset.jpeg";
+
+      expect(assets.isValidUrl(src)).toBe(true);
+    });
+
+    it("is `false` for other URLs", () => {
+      const src = "https://www.example.org/image.jpeg";
+
+      expect(assets.isValidUrl(src)).toBe(false);
+    });
+
+    it("is `false` for non-URLs", () => {
+      const src = "image.jpeg";
+
+      expect(assets.isValidUrl(src)).toBe(false);
+    });
+  });
+
+  describe("optimisedSrc", () => {
+    it("is `null` if no asset passed", () => {
+      expect(assets.optimisedSrc(null)).toBe(null);
+    });
+
+    it("is `null` if asset has no URL", () => {
+      expect(assets.optimisedSrc({ contentType: "image/jpeg" })).toBe(null);
+    });
+
+    it("compresses jpegs", () => {
+      const asset = {
+        url: "https://images.ctfassets.net/asset.jpeg",
+        contentType: "image/jpeg",
+      };
+
+      expect(assets.optimisedSrc(asset)).toBe(
+        "https://images.ctfassets.net/asset.jpeg?fm=webp&q=40",
+      );
+    });
+
+    it("joins all the options", () => {
+      const asset = {
+        url: "https://images.ctfassets.net/asset.jpeg",
+        contentType: "image/jpeg",
+      };
+
+      expect(assets.optimisedSrc(asset, { fm: "jpg", w: 200, q: 80 })).toBe(
+        "https://images.ctfassets.net/asset.jpeg?fm=jpg&w=200&q=80&fl=progressive",
+      );
+    });
+
+    it("applies passed max width", () => {
+      const asset = {
+        url: "https://images.ctfassets.net/asset.png",
+        contentType: "image/png",
+      };
+
+      expect(assets.optimisedSrc(asset, { w: 40 })).toBe(
+        "https://images.ctfassets.net/asset.png?w=40&fm=webp&q=40",
+      );
+    });
+  });
+
+  describe("imageDisplayProfileResponsiveSizes", () => {
+    it("removes sizes if profile present and has them disabled", () => {
+      const profile = {
+        sizes: ["small"],
+      };
+
+      const sizes = assets.imageDisplayProfileResponsiveSizes(
+        responsiveParams,
+        profile,
+      );
+
+      expect(sizes).toEqual({ small: responsiveParams.small });
+    });
+
+    it("removes height property if profile has fit: pad and crop: false", () => {
+      const profile = {
+        crop: false,
+        fit: "pad",
+        sizes: ["small"],
+      };
+
+      const sizes = { small: { w: 245, h: 440, fit: "pad" } };
+      const profileSizes = assets.imageDisplayProfileResponsiveSizes(
+        sizes,
+        profile,
+      );
+
+      expect(profileSizes).toEqual({ small: { w: 245, fit: "pad" } });
+    });
+  });
+
+  describe("responsiveImageSrcset", () => {
+    describe("when a Contentful asset and params are available", () => {
+      it("returns image srcset for all breakpoints", () => {
+        const asset = {
+          url: "https://images.ctfassets.net/asset.jpeg",
+          contentType: "image/jpeg",
+        };
+
+        const srcset = assets.responsiveImageSrcset(asset, responsiveParams);
+
+        expect(srcset).toContain(
+          "https://images.ctfassets.net/asset.jpeg?w=245&h=440&fit=fill&fm=webp&q=40 245w,https://images.ctfassets.net/asset.jpeg?w=260&h=420&fit=fill&fm=webp&q=40 260w,https://images.ctfassets.net/asset.jpeg?w=280&h=400&fit=fill&fm=webp&q=40 280w,https://images.ctfassets.net/asset.jpeg?w=300&h=400&fit=fill&fm=webp&q=40 300w,https://images.ctfassets.net/asset.jpeg?w=320&h=370&fit=fill&fm=webp&q=40 320w,https://images.ctfassets.net/asset.jpeg?w=355&h=345&fit=fill&fm=webp&q=40 355w,https://images.ctfassets.net/asset.jpeg?w=510&h=540&fit=fill&fm=webp&q=40 510w,https://images.ctfassets.net/asset.jpeg?w=700&h=900&fit=fill&fm=webp&q=40 700w",
+        );
+      });
+    });
+
+    describe("when a Contentful asset, but no params are available", () => {
+      it("returns `null`", () => {
+        const asset = {
+          url: "https://images.ctfassets.net/asset.jpeg",
+          contentType: "image/jpeg",
+        };
+
+        const srcset = assets.responsiveImageSrcset(asset);
+
+        expect(srcset).toBe(null);
+      });
+    });
+
+    describe("when not a Contentful asset", () => {
+      it("returns `null`", () => {
+        const asset = "image.jpeg";
+
+        const srcset = assets.responsiveImageSrcset(asset);
+
+        expect(srcset).toBe(null);
+      });
+    });
+  });
+
+  describe("responsiveBackgroundImageCSSVars", () => {
+    describe("when a Contentful asset and params are available", () => {
+      it("returns style definitions for all breakpoints", () => {
+        const asset = {
+          url: "https://images.ctfassets.net/asset.jpeg",
+          contentType: "image/jpeg",
+        };
+
+        const variables = assets.responsiveBackgroundImageCSSVars(
+          asset,
+          responsiveParams,
+        );
+        expect(variables["--bg-img-4k"]).toBeTruthy();
+      });
+    });
+
+    describe("when not a Contentful asset, but an image url is available", () => {
+      it("returns style definitions for small breakpoint", () => {
+        const asset = {
+          url: "https://www.europeana.eu/asset.jpeg",
+        };
+
+        const variables = assets.responsiveBackgroundImageCSSVars(asset);
+        expect(variables["--bg-img-small"]).toBeTruthy();
+        expect(variables["--bg-img-4k"]).toBeFalsy();
+      });
+    });
+
+    describe("when no image available", () => {
+      it("returns null", () => {
+        const asset = {};
+
+        const variables = assets.responsiveBackgroundImageCSSVars(asset);
+        expect(variables).toBe(null);
+      });
+    });
+  });
+});

--- a/packages/base/utils/rightsStatement.js
+++ b/packages/base/utils/rightsStatement.js
@@ -1,0 +1,159 @@
+const ICON_CLASS_BY = "icon-license-by";
+const ICON_CLASS_CC = "icon-license-cc";
+const ICON_CLASS_COPYRIGHT_NOT_EVALUATED = "icon-license-rs-unknown";
+const ICON_CLASS_IN_COPYRIGHT = "icon-license-rs-yes";
+const ICON_CLASS_NC = "icon-license-nc";
+const ICON_CLASS_ND = "icon-license-nd";
+const ICON_CLASS_NO_COPYRIGHT = "icon-license-rs-no";
+const ICON_CLASS_PUBLIC_DOMAIN = "icon-license-pd";
+const ICON_CLASS_RIGHTS_RESERVED = "icon-license-rr";
+const ICON_CLASS_SA = "icon-license-sa";
+const ICON_CLASS_ZERO = "icon-license-zero";
+const REUSABILITY_OPEN = "open";
+const REUSABILITY_RESTRICTED = "restricted";
+const REUSABILITY_PERMISSION = "permission";
+
+const rightsStatements = [
+  {
+    name: "Public Domain",
+    iconClass: [ICON_CLASS_PUBLIC_DOMAIN],
+    reusability: REUSABILITY_OPEN,
+    urls: [{ host: "creativecommons.org", path: "/publicdomain/mark/" }],
+  },
+  {
+    name: "CC0",
+    iconClass: [ICON_CLASS_ZERO],
+    reusability: REUSABILITY_OPEN,
+    urls: [{ host: "creativecommons.org", path: "/publicdomain/zero/" }],
+  },
+  {
+    name: "CC BY",
+    iconClass: [ICON_CLASS_CC, ICON_CLASS_BY],
+    reusability: REUSABILITY_OPEN,
+    urls: [{ host: "creativecommons.org", path: "/licenses/by/" }],
+  },
+  {
+    name: "CC BY-SA",
+    iconClass: [ICON_CLASS_CC, ICON_CLASS_BY, ICON_CLASS_SA],
+    reusability: REUSABILITY_OPEN,
+    urls: [{ host: "creativecommons.org", path: "/licenses/by-sa/" }],
+  },
+  {
+    name: "CC BY-NC",
+    iconClass: [ICON_CLASS_CC, ICON_CLASS_BY, ICON_CLASS_NC],
+    reusability: REUSABILITY_RESTRICTED,
+    urls: [{ host: "creativecommons.org", path: "/licenses/by-nc/" }],
+  },
+  {
+    name: "CC BY-NC-SA",
+    iconClass: [ICON_CLASS_CC, ICON_CLASS_BY, ICON_CLASS_NC, ICON_CLASS_SA],
+    reusability: REUSABILITY_RESTRICTED,
+    urls: [{ host: "creativecommons.org", path: "/licenses/by-nc-sa/" }],
+  },
+  {
+    name: "CC BY-NC-ND",
+    iconClass: [ICON_CLASS_CC, ICON_CLASS_BY, ICON_CLASS_NC, ICON_CLASS_ND],
+    reusability: REUSABILITY_RESTRICTED,
+    urls: [{ host: "creativecommons.org", path: "/licenses/by-nc-nd/" }],
+  },
+  {
+    name: "CC BY-ND",
+    iconClass: [ICON_CLASS_CC, ICON_CLASS_BY, ICON_CLASS_ND],
+    reusability: REUSABILITY_RESTRICTED,
+    urls: [{ host: "creativecommons.org", path: "/licenses/by-nd/" }],
+  },
+  {
+    name: "In Copyright - Educational Use Permitted",
+    iconClass: [ICON_CLASS_IN_COPYRIGHT],
+    reusability: REUSABILITY_RESTRICTED,
+    urls: [{ host: "rightsstatements.org", path: "/InC-EDU/" }],
+  },
+  {
+    name: "No Copyright - Non-Commercial Use Only",
+    iconClass: [ICON_CLASS_NO_COPYRIGHT],
+    reusability: REUSABILITY_RESTRICTED,
+    urls: [
+      { host: "rightsstatements.org", path: "/NoC-NC/" },
+      {
+        host: "www.europeana.eu",
+        path: "/rights/out-of-copyright-non-commercial/",
+      },
+    ],
+  },
+  {
+    name: "No Copyright - Other Known Legal Restrictions",
+    iconClass: [ICON_CLASS_NO_COPYRIGHT],
+    reusability: REUSABILITY_RESTRICTED,
+    urls: [{ host: "rightsstatements.org", path: "/NoC-OKLR/" }],
+  },
+  {
+    name: "Rights Reserved - Free Access",
+    iconClass: [ICON_CLASS_RIGHTS_RESERVED],
+    reusability: REUSABILITY_PERMISSION,
+    urls: [{ host: "www.europeana.eu", path: "/rights/rr-f/" }],
+  },
+  {
+    name: "Rights Reserved - Paid Access",
+    iconClass: [ICON_CLASS_RIGHTS_RESERVED],
+    reusability: REUSABILITY_PERMISSION,
+    urls: [{ host: "www.europeana.eu", path: "/rights/rr-p/" }],
+  },
+  {
+    name: "Rights Reserved - Restricted Access",
+    iconClass: [ICON_CLASS_RIGHTS_RESERVED],
+    reusability: REUSABILITY_PERMISSION,
+    urls: [{ host: "www.europeana.eu", path: "/rights/rr-r/" }],
+  },
+  {
+    name: "Unknown copyright status",
+    iconClass: [],
+    reusability: REUSABILITY_PERMISSION,
+    urls: [{ host: "www.europeana.eu", path: "/rights/unknown/" }],
+  },
+  {
+    name: "In Copyright",
+    iconClass: [ICON_CLASS_IN_COPYRIGHT],
+    reusability: REUSABILITY_PERMISSION,
+    urls: [{ host: "rightsstatements.org", path: "/InC/" }],
+  },
+  {
+    name: "In Copyright - EU Orphan Work",
+    iconClass: [ICON_CLASS_IN_COPYRIGHT],
+    reusability: REUSABILITY_PERMISSION,
+    urls: [{ host: "rightsstatements.org", path: "/InC-OW-EU/" }],
+  },
+  {
+    name: "Copyright Not Evaluated",
+    iconClass: [ICON_CLASS_COPYRIGHT_NOT_EVALUATED],
+    reusability: REUSABILITY_PERMISSION,
+    urls: [{ host: "rightsstatements.org", path: "/CNE/" }],
+  },
+];
+
+export default function rightsNameAndIcon(rightsStatementUrl) {
+  let rightsStatement;
+
+  try {
+    const url = new URL(rightsStatementUrl);
+    const match = rightsStatements.find((rs) =>
+      rs.urls.some((rsUrl) => {
+        return rsUrl.host === url.host && url.pathname.includes(rsUrl.path);
+      }),
+    );
+    if (match) {
+      rightsStatement = {
+        name: match.name,
+        iconClass: match.iconClass,
+        reusability: match.reusability,
+      };
+    } else {
+      throw new Error("No rights statement found");
+    }
+  } catch {
+    rightsStatement = {
+      name: rightsStatementUrl,
+    };
+  }
+
+  return rightsStatement;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,16 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, coverageConfigDefaults } from "vitest/config";
 
 export default defineConfig({
   test: {
     include: ["**/*.spec.js"],
     projects: ["packages/apps/*"],
+    coverage: {
+      exclude: [
+        ...coverageConfigDefaults.exclude,
+        "**/*.stories.ts",
+        "**/*.config.[jt]s",
+        "packages/apps/ds4ch/i18n/*",
+      ],
+    },
   },
 });


### PR DESCRIPTION
Creates components, all duplicates from the portal.js app, refactored to Nuxt 3 + Bootstrap 5:
- ImageWithAttribution and its child components:
  - ImageOptimised
    - ImageEagerOrLazy
  - ImageAttributionToggle
    - ImageCiteAttribution
      - RightsStatement

And:
- Adds sample image data to be used in Storybook (copied from portal.js)
- Adds ignore paths for test coverage