### PR TITLE
feat: product sub section

### DIFF
--- a/packages/apps/ds4ch/assets/scss/buttons.scss
+++ b/packages/apps/ds4ch/assets/scss/buttons.scss
@@ -1,3 +1,4 @@
+.landing-page.xxl-page .btn,
 .btn {
   &.icon-chevron {
     line-height: 1.5;

--- a/packages/apps/ds4ch/assets/scss/default.scss
+++ b/packages/apps/ds4ch/assets/scss/default.scss
@@ -5,3 +5,66 @@ main {
     margin-top: $page-header-height-4k;
   }
 }
+
+// base component DS4CH specific overrides
+div.landing-sub-section {
+  background-color: $black;
+  color: $white;
+
+  .header {
+    padding-bottom: 2rem;
+
+    @media (min-width: $bp-large) {
+      padding-bottom: 4rem;
+    }
+
+    @media (min-width: $bp-4k) {
+      padding-bottom: 10rem;
+    }
+  }
+}
+
+.landing-page.xxl-page {
+  .landing-sub-section {
+    h2 {
+      @extend %title-1;
+    }
+
+    h3 {
+      @extend %title-2;
+    }
+
+    .image-card {
+      padding-top: 0;
+      padding-bottom: 0;
+
+      @media (min-width: $bp-xxl) {
+        max-width: 1500px;
+      }
+
+      @media (min-width: $bp-extralarge) {
+        margin-left: -4rem;
+        margin-right: -4rem;
+      }
+
+      @media (min-width: $bp-xxl) {
+        margin-left: auto;
+        margin-right: auto;
+      }
+
+      @media (min-width: $bp-4k) {
+        max-width: 3000px;
+      }
+
+      &.image-card-odd {
+        .text-wrapper {
+          padding-right: 0;
+        }
+      }
+
+      .text-wrapper .text {
+        color: $white;
+      }
+    }
+  }
+}

--- a/packages/apps/ds4ch/assets/scss/grid.scss
+++ b/packages/apps/ds4ch/assets/scss/grid.scss
@@ -1,0 +1,14 @@
+.container {
+  padding-left: 2rem;
+  padding-right: 2rem;
+
+  @media (min-width: ($bp-extralarge)) {
+    padding-left: 4rem;
+    padding-right: 4rem;
+  }
+
+  @media (min-width: ($bp-4k)) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}

--- a/packages/apps/ds4ch/assets/scss/main.scss
+++ b/packages/apps/ds4ch/assets/scss/main.scss
@@ -15,4 +15,5 @@
 @import "variables";
 @import "default";
 @import "buttons";
+@import "grid";
 @import "text";

--- a/packages/apps/ds4ch/assets/scss/variables.scss
+++ b/packages/apps/ds4ch/assets/scss/variables.scss
@@ -21,9 +21,25 @@ $font-size-34: 2.125rem;
 $font-size-38: 2.375rem;
 $font-size-40: 2.5rem;
 $font-size-56: 3.5rem;
+$font-size-68: 4.25rem;
 
 $page-header-height: 5.25rem;
 $page-header-height-4k: 10.5rem;
+
+%title-1 {
+  font-family: $font-family-montserrat;
+  font-size: $font-size-24;
+  font-weight: 700;
+
+  @media (min-width: $bp-large) {
+    font-size: $font-size-34;
+  }
+
+  @media (min-width: $bp-4k) {
+    font-size: $font-size-68;
+  }
+}
+
 %title-2 {
   font-family: $font-family-montserrat;
   font-size: $font-size-20;

--- a/packages/apps/ds4ch/graphql/queries/landingPage.graphql
+++ b/packages/apps/ds4ch/graphql/queries/landingPage.graphql
@@ -22,6 +22,19 @@ query LandingPage(
           ... on ImageCard {
             ...imageCardFields
           }
+          ... on LandingSubSection {
+            name
+            nameEN: name(locale: "en-GB")
+            text
+            hasPartCollection(limit: 6) {
+              items {
+                __typename
+                ... on ImageCard {
+                  ...imageCardFields
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/packages/apps/ds4ch/pages/index.vue
+++ b/packages/apps/ds4ch/pages/index.vue
@@ -49,6 +49,13 @@ const getClasses = (section) => {
       >
         <ImageTextCard :card="section" />
       </div>
+      <LandingSubSection
+        v-else-if="contentfulEntryHasContentType(section, 'LandingSubSection')"
+        :title="section.name"
+        :text="section.text"
+        :sections="section.hasPartCollection && section.hasPartCollection.items"
+        image-card-cta-classes="btn-primary icon-chevron"
+      />
     </div>
   </div>
 </template>

--- a/packages/base/components/Landing/LandingImageCard.vue
+++ b/packages/base/components/Landing/LandingImageCard.vue
@@ -96,7 +96,7 @@ const isSVG = cardImageWithAttribution?.image?.contentType === "image/svg+xml";
   </div>
 </template>
 
-<style lang="scss" scoped>
+<style lang="scss">
 @import "@europeana/style/scss/variables";
 
 .image-card {
@@ -149,7 +149,6 @@ const isSVG = cardImageWithAttribution?.image?.contentType === "image/svg+xml";
   .text-wrapper {
     @media (min-width: $bp-large) {
       flex: 0 0 51%;
-      background-color: $white;
       padding-left: 3.625rem;
       padding-right: 2rem;
     }
@@ -187,23 +186,18 @@ const isSVG = cardImageWithAttribution?.image?.contentType === "image/svg+xml";
     }
   }
 
-  :deep(figure) {
+  figure {
     margin: 0;
     width: 100%;
     height: auto;
-  }
 
-  figure {
-    width: 100%;
-    height: auto;
-
-    :deep(img) {
+    img {
       width: 100%;
       height: auto;
     }
   }
 
-  :deep(figcaption) {
+  figcaption {
     @media (min-width: $bp-4k) {
       .icon-info {
         width: 3.125rem;
@@ -239,7 +233,6 @@ const isSVG = cardImageWithAttribution?.image?.contentType === "image/svg+xml";
   }
 
   .text {
-    color: $darkgrey;
     text-align: left;
   }
 }

--- a/packages/base/components/Landing/LandingSubSection.spec.js
+++ b/packages/base/components/Landing/LandingSubSection.spec.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { shallowMount } from "@vue/test-utils";
+
+import LandingSubSection from "./LandingSubSection.vue";
+
+describe("components/Landing/LandingSubSection", () => {
+  it("displays a title", () => {
+    const title = "Title for a sub section";
+    const wrapper = shallowMount(LandingSubSection, { props: { title } });
+
+    const titleElement = wrapper.find("h2");
+
+    expect(titleElement.text()).toBe(title);
+  });
+
+  it("displays text", () => {
+    const text = "Text for a sub section";
+    const wrapper = shallowMount(LandingSubSection, { props: { text } });
+
+    const textElement = wrapper.find(".text");
+
+    expect(textElement.text()).toBe(text);
+  });
+
+  describe("when there are image card sections", () => {
+    it("displays the sections", () => {
+      const sections = [{ __typename: "ImageCard" }];
+
+      const wrapper = shallowMount(LandingSubSection, { props: { sections } });
+
+      const imageCardElement = wrapper.find("landing-image-card-stub");
+
+      expect(imageCardElement.exists()).toBe(true);
+    });
+    it("passes the imageCardCtaClasses prop", () => {
+      const sections = [{ __typename: "ImageCard" }];
+      const imageCardCtaClasses = "btn-primary";
+
+      const wrapper = shallowMount(LandingSubSection, {
+        props: { sections, imageCardCtaClasses },
+      });
+
+      const imageCardElement = wrapper.getComponent({
+        name: "LandingImageCard",
+      });
+
+      expect(imageCardElement.props("ctaClasses")).toEqual(imageCardCtaClasses);
+    });
+  });
+});

--- a/packages/base/components/Landing/LandingSubSection.stories.ts
+++ b/packages/base/components/Landing/LandingSubSection.stories.ts
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@nuxtjs/storybook";
+
+import LandingSubSection from "./LandingSubSection.vue";
+import sampleData from "../../../apps/ds4ch/.storybook/sample-data.js";
+
+const meta = {
+  component: LandingSubSection,
+} satisfies Meta<typeof LandingSubSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: "Landing sub section title",
+    text: "Landing sub section text that will display below the title. This is text _with_ possible *markup* and a [link](https://www.europeana.eu)",
+    sections: [
+      {
+        __typename: "ImageCard",
+        name: "Card title",
+        text: "This text contains info. It can be __marked__ and accompanied by an image. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+        image: sampleData.imagesWithAttribution[0],
+        link: { text: "read more", url: "/" },
+      },
+    ],
+  },
+};
+
+export const PrimaryCta: Story = {
+  args: {
+    title: "Landing sub section title",
+    text: "Landing sub section text that will display below the title. This is text _with_ possible *markup* and a [link](https://www.europeana.eu)",
+    sections: [
+      {
+        __typename: "ImageCard",
+        name: "Card title",
+        text: "This text contains info. It can be __marked__ and accompanied by an image. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+        image: sampleData.imagesWithAttribution[0],
+        link: { text: "read more", url: "/" },
+      },
+    ],
+    imageCardCtaClasses: "btn-primary icon-chevron",
+  },
+};

--- a/packages/base/components/Landing/LandingSubSection.vue
+++ b/packages/base/components/Landing/LandingSubSection.vue
@@ -1,0 +1,116 @@
+<script setup>
+import contentfulEntryHasContentType from "../../utils/contentful/entryHasContentType.js";
+import parseMarkdown from "../../utils/markdown/parse.js";
+
+defineProps({
+  /**
+   * H2 title to display above the info cards
+   */
+  title: {
+    type: String,
+    default: null,
+  },
+  /**
+   * Text to display under title and above the info cards
+   */
+  text: {
+    type: String,
+    default: null,
+  },
+  /**
+   * List of sections
+   */
+  sections: {
+    type: Array,
+    default: () => [],
+  },
+  /**
+   * ImageCard CTA style
+   * @values primary-outline, secondary icon-chevron
+   */
+  imageCardCtaClasses: {
+    type: String,
+    default: "btn-outline-primary",
+  },
+});
+</script>
+<template>
+  <div class="landing-sub-section">
+    <div class="container landing-sub-section-container">
+      <div class="header mx-auto">
+        <h2 class="mx-auto">
+          {{ title }}
+        </h2>
+        <!-- eslint-disable vue/no-v-html -->
+        <div
+          v-if="text"
+          class="text mx-auto mb-3"
+          v-html="parseMarkdown(text)"
+        />
+        <!-- eslint-enable vue/no-v-html -->
+      </div>
+      <div v-for="(section, index) in sections" :key="index">
+        <LandingImageCard
+          v-if="contentfulEntryHasContentType(section, 'ImageCard')"
+          :card="section"
+          title-tag="h3"
+          :cta-classes="imageCardCtaClasses"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+@import "@europeana/style/scss/variables";
+
+.landing-sub-section {
+  .landing-sub-section-container {
+    padding-top: 3rem;
+    border-bottom: 1px solid transparent; // fix for when any margin of the last child component causes different bg to display
+
+    @media (min-width: $bp-large) {
+      padding-top: 6rem;
+    }
+
+    @media (min-width: $bp-4k) {
+      padding-top: 15rem;
+    }
+  }
+
+  .header {
+    max-width: 1250px;
+    padding-bottom: 1rem;
+    text-align: center;
+
+    @media (min-width: $bp-medium) {
+      padding-bottom: 4rem;
+    }
+
+    @media (min-width: $bp-4k) {
+      max-width: 2500px;
+      padding-bottom: 8rem;
+    }
+
+    h2 {
+      max-width: $max-text-column-width;
+
+      @media (min-width: $bp-4k) {
+        max-width: $max-text-column-width-landing-4k;
+      }
+    }
+  }
+
+  .text {
+    max-width: $max-text-column-width;
+
+    @media (min-width: $bp-4k) {
+      max-width: $max-text-column-width-landing-4k;
+    }
+  }
+
+  .landing-content-card-group .container {
+    max-width: none;
+  }
+}
+</style>


### PR DESCRIPTION
- Extends the landingPage GraphQL query to fetch sub sections, limited to image card sections for now
- Adds new LandingSubSection component to the base layer
- DS4CH style overrides for LandingSubSection in default.scss (to prevent the need for a DS4CH wrapper component)
- Introduces `%title-1` SCSS variable, can be reused for the hero banners (not home page)