### PR TITLE
feat: featured tags on content hub pages

### DIFF
--- a/packages/apps/ds4ch/assets/scss/text.scss
+++ b/packages/apps/ds4ch/assets/scss/text.scss
@@ -75,17 +75,6 @@ h5 {
     }
   }
 
-  h2.related-heading {
-    font-size: $font-size-14;
-    font-weight: 600;
-    margin-bottom: 0.75rem;
-
-    @media (min-width: $bp-4k) {
-      font-size: $font-size-28;
-      margin-bottom: 1.5rem;
-    }
-  }
-
   .related-container {
     margin-top: 1.5rem;
 

--- a/packages/apps/ds4ch/i18n/locales/en.json
+++ b/packages/apps/ds4ch/i18n/locales/en.json
@@ -19,7 +19,9 @@
   "categories": {
     "label": "Explore by tag",
     "noOptions": "There are no more tags to select",
-    "search": "Explore by tag"
+    "search": "Explore by tag",
+    "moreTags": "More tags",
+    "featuredTags": "Featured tags"
   },
   "content": {
     "filter": {

--- a/packages/apps/ds4ch/pages/data-space.vue
+++ b/packages/apps/ds4ch/pages/data-space.vue
@@ -23,6 +23,22 @@ useHead({
   title: page.value.headline,
 });
 
+const featuredTags = [
+  "3d",
+  "artificial-intelligence",
+  "copyright",
+  "extended-reality",
+  "academic-research",
+  "education",
+  "tourism",
+  "funding",
+  "impact",
+  "multilinguality",
+  "digital-storytelling",
+  "diversity-and-inclusion",
+  "reuse",
+];
+
 const defaultCardThumbnail = {
   image: { url: useRuntimeConfig().public.defaultThumbnail },
 };
@@ -41,6 +57,7 @@ const defaultCardThumbnail = {
       site="dataspace-culturalheritage.eu"
       :content-types="page.contentTypes"
       :default-card-thumbnail="defaultCardThumbnail"
+      :featured-tags="featuredTags"
       :cta-banners="page.hasPartCollection?.items"
     />
   </div>

--- a/packages/apps/ds4ch/pages/news/[slug].vue
+++ b/packages/apps/ds4ch/pages/news/[slug].vue
@@ -127,6 +127,7 @@ const truncatedAttachmentLabel = (attachment) => {
           <RelatedCategoryTags
             v-if="tags"
             :tags="tags"
+            :heading="$t('related.categoryTags.title')"
             class="related-container"
             route-name="data-space"
             badge-variant="badge-secondary"

--- a/packages/apps/ds4ch/pages/projects/[slug].vue
+++ b/packages/apps/ds4ch/pages/projects/[slug].vue
@@ -204,6 +204,7 @@ useHead({
           <RelatedCategoryTags
             v-if="tags"
             :tags="tags"
+            :heading="$t('related.categoryTags.title')"
             class="related-container"
             route-name="data-space"
             badge-variant="badge-secondary"

--- a/packages/base/components/Content/ContentInterface.vue
+++ b/packages/base/components/Content/ContentInterface.vue
@@ -14,6 +14,14 @@ const props = defineProps({
     type: Array,
     default: () => [],
   },
+  /**
+   * Tags for the category dropdown.
+   * Do not set to omit featured section.
+   */
+  featuredTags: {
+    type: Array,
+    default: null,
+  },
   featuredEntry: {
     type: Object,
     default: () => {},
@@ -284,6 +292,7 @@ watch(page, () => {
     <div class="container">
       <client-only>
         <ContentTagsDropdown
+          :featured-tags="featuredTags"
           :filtered-tags="filteredTags"
           :selected-tags="selectedTags"
         />

--- a/packages/base/components/Content/ContentTagsDropdown.spec.js
+++ b/packages/base/components/Content/ContentTagsDropdown.spec.js
@@ -39,7 +39,7 @@ const factory = async (props) =>
         },
       },
     },
-    propsData: props,
+    props,
   });
 
 describe("components/content/contentTagsDropdown", () => {
@@ -67,17 +67,55 @@ describe("components/content/contentTagsDropdown", () => {
     });
   });
 
+  describe("featured tags", () => {
+    describe("when featured tags are supplied as props", () => {
+      it("splits the tags into featured and non-featured sections", async () => {
+        useRouteMock.mockImplementation(() => ({
+          query: {},
+        }));
+        const wrapper = await factory({
+          featuredTags: ["3d"],
+          filteredTags: ["3d", "cooking", "postcards"],
+          selectedTags: ["cooking"],
+        });
+        await wrapper.vm.handleFocusin(); // open dropdown
+
+        const tagSectionHedings = wrapper.findAll("h2.related-heading");
+
+        expect(tagSectionHedings[0].text()).toMatch("categories.featuredTags");
+        expect(tagSectionHedings[1].text()).toMatch("categories.moreTags");
+      });
+    });
+    describe("when no featured tags are supplied", () => {
+      it("does not create seperate sections or add section headers", async () => {
+        useRouteMock.mockImplementation(() => ({
+          query: {},
+        }));
+        const wrapper = await factory({
+          filteredTags: ["3d", "cooking", "postcards"],
+          selectedTags: ["cooking"],
+        });
+        await wrapper.vm.handleFocusin(); // open dropdown
+
+        const tagSectionHedings = wrapper.find("h2.related-heading");
+        expect(tagSectionHedings.exists()).toBe(false);
+      });
+    });
+  });
+
   // TODO: The following tests don't work due to issues with setting data/props
   // and re-calculating computed properties.
 
-  //   describe('when searching for tag', () => {
-  //     it('filters by keyword', async() => {
-  //       const wrapper = await factory();
-  //       expect(wrapper.vm).toBe('post');
-  //       wrapper.vm.searchTag.value = 'post';
-  //       expect(wrapper.vm.displayTags.length).toBe(1);
-  //     });
+  // describe('when searching for tag', () => {
+  //   it('filters by keyword', async() => {
+  //     useRouteMock.mockImplementation(() => ({
+  //       query: {},
+  //     }));
+  //     const wrapper = await factory();
+  //     wrapper.vm.searchTag.value = 'post';
+  //     expect(wrapper.vm.allDisplayTags.length).toBe(1);
   //   });
+  // });
 
   //   describe('showDropdown', () => {
   //     it('toggles the tag dropdown', async() => {

--- a/packages/base/components/Related/RelatedCategoryTags.vue
+++ b/packages/base/components/Related/RelatedCategoryTags.vue
@@ -17,11 +17,11 @@ const props = defineProps({
     default: () => [],
   },
   /**
-   * Toggle to show or hide the heading
+   * Text to use as a heading. If omitted no title will show.
    */
   heading: {
-    type: Boolean,
-    default: true,
+    type: String,
+    default: null,
   },
   /**
    * Name of the route which the tags link to
@@ -75,10 +75,10 @@ const isActive = (tagId) => {
 //   }
 // }
 const handleLeft = (event) => {
-  event.target.previousSibling?.focus();
+  event.target.previousElementSibling?.focus();
 };
 const handleRight = (event) => {
-  event.target.nextSibling?.focus();
+  event.target.nextElementSibling?.focus();
 };
 </script>
 <template>
@@ -89,7 +89,7 @@ const handleRight = (event) => {
       class="col col-12"
     >
       <h2 v-if="heading" class="related-heading text-uppercase">
-        {{ $t("related.categoryTags.title") }}
+        {{ heading }}
       </h2>
       <div class="d-flex">
         <span class="icon-ic-tag" />
@@ -119,6 +119,7 @@ const handleRight = (event) => {
 
 <style lang="scss" scoped>
 @import "@europeana/style/scss/variables";
+@import "assets/scss/variables";
 
 .icon-ic-tag {
   color: $darkgrey;
@@ -150,6 +151,17 @@ const handleRight = (event) => {
     @media (min-width: $bp-4k) {
       margin: 0 0.5rem 0.75rem;
     }
+  }
+}
+
+h2.related-heading {
+  font-size: $font-size-14;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+
+  @media (min-width: $bp-4k) {
+    font-size: $font-size-28;
+    margin-bottom: 1.5rem;
   }
 }
 </style>


### PR DESCRIPTION
Hardcodes featured tags on /data-space page.
These are picked up in the ContentTagsDropdown, if present there two sections are used.