### PR TITLE
feat(map): spread out clusters at high zoom levels

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.1",
+  "version": "0.1.2-map.0",
   "npmClient": "pnpm"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.3-map.2",
+  "version": "0.1.3-map.3",
   "npmClient": "pnpm"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.2",
+  "version": "0.1.3-map.0",
   "npmClient": "pnpm"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.3-map.1",
+  "version": "0.1.3-map.2",
   "npmClient": "pnpm"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.1.3-map.0",
+  "version": "0.1.3-map.1",
   "npmClient": "pnpm"
 }

--- a/packages/apps/ds4ch/package.json
+++ b/packages/apps/ds4ch/package.json
@@ -25,7 +25,7 @@
     "@vitejs/plugin-vue": "6.0.7",
     "bootstrap": "5.3.8",
     "happy-dom": "20.10.6",
-    "lodash-es": "4.18.1",
+    "lodash-es": "catalog:",
     "nuxt": "catalog:nuxt3",
     "sass-embedded": "1.100.0",
     "storybook": "10.4.6",

--- a/packages/apps/ds4ch/package.json
+++ b/packages/apps/ds4ch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@europeana/ds4ch",
   "type": "module",
-  "version": "0.1.3-map.0",
+  "version": "0.1.3-map.1",
   "main": "./nuxt.config.ts",
   "scripts": {
     "build": "nuxt build",

--- a/packages/apps/ds4ch/package.json
+++ b/packages/apps/ds4ch/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@europeana/ds4ch",
   "type": "module",
-  "version": "0.1.2",
+  "version": "0.1.3-map.0",
   "main": "./nuxt.config.ts",
   "scripts": {
     "build": "nuxt build",

--- a/packages/components/map/package.json
+++ b/packages/components/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@europeana/map",
-  "version": "0.1.1",
+  "version": "0.1.2-map.0",
   "description": "Vue 3 component/app to show a map on which clustered points may be displayed.",
   "license": "EUPL-1.2",
   "type": "module",

--- a/packages/components/map/package.json
+++ b/packages/components/map/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@vueuse/core": "catalog:vue3",
+    "lodash-es": "catalog:",
     "ol": "catalog:",
     "ol-mapbox-style": "^13.4.1"
   },

--- a/packages/components/map/package.json
+++ b/packages/components/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@europeana/map",
-  "version": "0.1.3-map.1",
+  "version": "0.1.3-map.2",
   "description": "Vue 3 component/app to show a map on which clustered points may be displayed.",
   "license": "EUPL-1.2",
   "type": "module",

--- a/packages/components/map/package.json
+++ b/packages/components/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@europeana/map",
-  "version": "0.1.2",
+  "version": "0.1.3-map.0",
   "description": "Vue 3 component/app to show a map on which clustered points may be displayed.",
   "license": "EUPL-1.2",
   "type": "module",

--- a/packages/components/map/package.json
+++ b/packages/components/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@europeana/map",
-  "version": "0.1.3-map.2",
+  "version": "0.1.3-map.3",
   "description": "Vue 3 component/app to show a map on which clustered points may be displayed.",
   "license": "EUPL-1.2",
   "type": "module",

--- a/packages/components/map/package.json
+++ b/packages/components/map/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@europeana/map",
-  "version": "0.1.3-map.0",
+  "version": "0.1.3-map.1",
   "description": "Vue 3 component/app to show a map on which clustered points may be displayed.",
   "license": "EUPL-1.2",
   "type": "module",

--- a/packages/components/map/src/components/EuropeanaMap.vue
+++ b/packages/components/map/src/components/EuropeanaMap.vue
@@ -4,6 +4,7 @@ import { useFetch } from "@vueuse/core";
 import "ol/ol.css";
 
 import { useOpenLayersMap } from "@/composables/openLayersMap.js";
+import { useOpenLayersFeatureStyles } from "@/composables/openLayersFeatureStyles.js";
 import { useOpenLayersPointClusters } from "@/composables/openLayersPointClusters.js";
 import pointIconSrc from "@/assets/img/ic_location.svg";
 
@@ -59,6 +60,11 @@ if (json.value) {
 }
 
 const target = "europeana-map-map";
+const icon = {
+  src: pointIconSrc,
+  width: 32,
+  height: 32,
+};
 
 useOpenLayersMap({
   centre,
@@ -68,10 +74,15 @@ useOpenLayersMap({
   target,
   zoom,
 });
+const { getSingleFeatureStyleMinDimension, styleFeature } =
+  useOpenLayersFeatureStyles({ icon, map });
+const singleFeatureStyleMinDimension = getSingleFeatureStyleMinDimension();
 useOpenLayersPointClusters({
   data,
+  distance: singleFeatureStyleMinDimension * 1.5,
+  minDistance: singleFeatureStyleMinDimension * 0.75,
   map,
-  pointIconSrc,
+  styleFeature,
 });
 </script>
 

--- a/packages/components/map/src/components/EuropeanaMap.vue
+++ b/packages/components/map/src/components/EuropeanaMap.vue
@@ -62,8 +62,8 @@ if (json.value) {
 const target = "europeana-map-map";
 const icon = {
   src: pointIconSrc,
-  width: 32,
-  height: 32,
+  width: 24,
+  height: 24,
 };
 
 useOpenLayersMap({

--- a/packages/components/map/src/composables/openLayersFeatureStyles.js
+++ b/packages/components/map/src/composables/openLayersFeatureStyles.js
@@ -43,7 +43,7 @@ export const useOpenLayersFeatureStyles = ({ icon, map }) => {
     return styleCache[key];
   };
 
-  const moveGeometry = (geometry, distance, angle) => {
+  const getNewCoordinates = (geometry, distance, angle) => {
     const originalCoordinates = geometry.getCoordinates();
     const originalPixel =
       mapRef.value.getPixelFromCoordinate(originalCoordinates);
@@ -55,7 +55,11 @@ export const useOpenLayersFeatureStyles = ({ icon, map }) => {
       originalPixel[0] + displacementX,
       originalPixel[1] + displacementY,
     ];
-    const newCoordinates = mapRef.value.getCoordinateFromPixel(newPixel);
+    return mapRef.value.getCoordinateFromPixel(newPixel);
+  };
+
+  const moveGeometry = (geometry, distance, angle) => {
+    const newCoordinates = getNewCoordinates(geometry, distance, angle);
 
     geometry.setCoordinates(newCoordinates);
   };
@@ -69,7 +73,7 @@ export const useOpenLayersFeatureStyles = ({ icon, map }) => {
       // of the spokes
       new Style({
         image: new CircleStyle({
-          radius: 4,
+          radius: 3,
           stroke: new Stroke({
             color: "#000",
           }),
@@ -81,7 +85,7 @@ export const useOpenLayersFeatureStyles = ({ icon, map }) => {
       }),
     ];
 
-    const distance = getSingleFeatureStyleMinDimension() * 0.75; // in pixels
+    const distance = getSingleFeatureStyleMinDimension(); // in pixels
     const unitAngle = degreesToRadians(360) / features.length;
 
     // for each feature, draw a point marker, moved out from the
@@ -91,7 +95,11 @@ export const useOpenLayersFeatureStyles = ({ icon, map }) => {
       const pointGeometry = feature.getGeometry().clone();
       const originalCoordinates = pointGeometry.getCoordinates();
       moveGeometry(pointGeometry, distance, angle);
-      const newCoordinates = pointGeometry.getCoordinates();
+      const newCoordinates = getNewCoordinates(
+        pointGeometry,
+        -distance / 4,
+        angle,
+      );
 
       const pointStyle = styleSingleFeature().clone();
       pointStyle.setGeometry(pointGeometry);
@@ -101,7 +109,7 @@ export const useOpenLayersFeatureStyles = ({ icon, map }) => {
         geometry: new LineString([originalCoordinates, newCoordinates]),
         stroke: new Stroke({
           color: "#000",
-          width: 2,
+          width: 1,
         }),
       });
       styles.push(lineStyle);
@@ -111,9 +119,10 @@ export const useOpenLayersFeatureStyles = ({ icon, map }) => {
   };
 
   const getNumberedCircleStyle = (number) => {
+    const radius = number >= 100 ? 16 : 12;
     return new Style({
       image: new CircleStyle({
-        radius: 14,
+        radius,
         stroke: new Stroke({
           color: "#000",
         }),

--- a/packages/components/map/src/composables/openLayersFeatureStyles.js
+++ b/packages/components/map/src/composables/openLayersFeatureStyles.js
@@ -1,0 +1,170 @@
+import { toRef } from "vue";
+import { uniqWith, isEqual } from "lodash-es";
+
+import CircleStyle from "ol/style/Circle.js";
+import Fill from "ol/style/Fill.js";
+import Icon from "ol/style/Icon.js";
+import LineString from "ol/geom/LineString.js";
+import Stroke from "ol/style/Stroke.js";
+import Style from "ol/style/Style.js";
+import Text from "ol/style/Text.js";
+
+export const useOpenLayersFeatureStyles = ({ icon, map }) => {
+  const mapRef = toRef(map);
+  const styleCache = {};
+
+  const degreesToRadians = (degrees) => {
+    return degrees * (Math.PI / 180);
+  };
+
+  const getSingleFeatureStyleMinDimension = () => {
+    if (icon) {
+      return Math.min(icon.width, icon.height);
+    } else {
+      return getNumberedCircleStyle(1).getImage().radius * 2;
+    }
+  };
+
+  const styleSingleFeature = () =>
+    cachingStyle(1, () => {
+      if (icon) {
+        return new Style({
+          image: new Icon(icon),
+        });
+      } else {
+        return getNumberedCircleStyle(1);
+      }
+    });
+
+  const cachingStyle = (key, generatorFn) => {
+    if (!styleCache[key]) {
+      styleCache[key] = generatorFn();
+    }
+    return styleCache[key];
+  };
+
+  const moveGeometry = (geometry, distance, angle) => {
+    const originalCoordinates = geometry.getCoordinates();
+    const originalPixel =
+      mapRef.value.getPixelFromCoordinate(originalCoordinates);
+
+    const displacementX = distance * Math.sin(angle);
+    const displacementY = distance * Math.cos(angle);
+
+    const newPixel = [
+      originalPixel[0] + displacementX,
+      originalPixel[1] + displacementY,
+    ];
+    const newCoordinates = mapRef.value.getCoordinateFromPixel(newPixel);
+
+    geometry.setCoordinates(newCoordinates);
+  };
+
+  // style multiple features at the same co-ordinates as spokes coming from
+  // a dot at the centre point (the original co-ordinates) to a marker for
+  // each of the features moved away from the centre in a different direction
+  const styleMultipleFeaturesSpread = (features) => {
+    const styles = [
+      // put a small circle at the original co-ordinates, i.e. at the centre
+      // of the spokes
+      new Style({
+        image: new CircleStyle({
+          radius: 4,
+          stroke: new Stroke({
+            color: "#000",
+          }),
+          fill: new Fill({
+            color: "#000",
+          }),
+        }),
+        geometry: features[0].getGeometry(),
+      }),
+    ];
+
+    const distance = getSingleFeatureStyleMinDimension() * 0.75; // in pixels
+    const unitAngle = degreesToRadians(360) / features.length;
+
+    // for each feature, draw a point marker, moved out from the
+    // centre, and a line from it to the centre
+    features.forEach((feature, index) => {
+      const angle = unitAngle * index;
+      const pointGeometry = feature.getGeometry().clone();
+      const originalCoordinates = pointGeometry.getCoordinates();
+      moveGeometry(pointGeometry, distance, angle);
+      const newCoordinates = pointGeometry.getCoordinates();
+
+      const pointStyle = styleSingleFeature().clone();
+      pointStyle.setGeometry(pointGeometry);
+      styles.push(pointStyle);
+
+      const lineStyle = new Style({
+        geometry: new LineString([originalCoordinates, newCoordinates]),
+        stroke: new Stroke({
+          color: "#000",
+          width: 2,
+        }),
+      });
+      styles.push(lineStyle);
+    });
+
+    return styles;
+  };
+
+  const getNumberedCircleStyle = (number) => {
+    return new Style({
+      image: new CircleStyle({
+        radius: 14,
+        stroke: new Stroke({
+          color: "#000",
+        }),
+        fill: new Fill({
+          color: "#000",
+        }),
+      }),
+      text: new Text({
+        text: number.toString(),
+        fill: new Fill({
+          color: "#fff",
+        }),
+        font: '700 0.875rem "Open Sans", "Arial", sans-serif',
+      }),
+    });
+  };
+
+  const styleMultipleFeaturesClustered = (features) =>
+    cachingStyle(features.length, () =>
+      getNumberedCircleStyle(features.length),
+    );
+
+  const styleMultipleFeatures = (features) => {
+    const zoom = mapRef.value.getView().getZoom();
+
+    // only break clusters apart at zoom level 16+, and if all features are
+    // at exactly the same co-ordinates
+    if (
+      zoom >= 16 &&
+      features.length >= 2 &&
+      uniqWith(
+        features.map((f) => f.getGeometry().getCoordinates()),
+        isEqual,
+      ).length === 1
+    ) {
+      return styleMultipleFeaturesSpread(features);
+    } else {
+      return styleMultipleFeaturesClustered(features);
+    }
+  };
+
+  const styleFeature = (feature) => {
+    const features = feature.get("features");
+    const size = features?.length || 0;
+
+    if (size === 1) {
+      return styleSingleFeature();
+    } else {
+      return styleMultipleFeatures(features);
+    }
+  };
+
+  return { getSingleFeatureStyleMinDimension, styleFeature };
+};

--- a/packages/components/map/src/composables/openLayersFeatureStyles.js
+++ b/packages/components/map/src/composables/openLayersFeatureStyles.js
@@ -95,11 +95,7 @@ export const useOpenLayersFeatureStyles = ({ icon, map }) => {
       const pointGeometry = feature.getGeometry().clone();
       const originalCoordinates = pointGeometry.getCoordinates();
       moveGeometry(pointGeometry, distance, angle);
-      const newCoordinates = getNewCoordinates(
-        pointGeometry,
-        -distance / 4,
-        angle,
-      );
+      const newCoordinates = pointGeometry.getCoordinates();
 
       const pointStyle = styleSingleFeature().clone();
       pointStyle.setGeometry(pointGeometry);

--- a/packages/components/map/src/composables/openLayersFeatureStyles.spec.js
+++ b/packages/components/map/src/composables/openLayersFeatureStyles.spec.js
@@ -81,7 +81,7 @@ describe("@/composables/openLayersFeatureStyles.spec.js", () => {
             const styleFeature = wrapper.vm.styleFeature;
             const style = styleFeature(feature);
 
-            expect(style.getImage().radius).toBe(14);
+            expect(style.getImage().radius).toBe(12);
             expect(style.getText().getText()).toBe("1");
           });
         });
@@ -104,7 +104,7 @@ describe("@/composables/openLayersFeatureStyles.spec.js", () => {
             const styleFeature = wrapper.vm.styleFeature;
             const style = styleFeature(feature);
 
-            expect(style.getImage().radius).toBe(14);
+            expect(style.getImage().radius).toBe(12);
             expect(style.getText().getText()).toBe("2");
           });
         });
@@ -118,7 +118,7 @@ describe("@/composables/openLayersFeatureStyles.spec.js", () => {
             const styleFeature = wrapper.vm.styleFeature;
             const style = styleFeature(feature);
 
-            expect(style.length).toBe(5);
+            expect(style).toHaveLength(5);
             expect(style[0].getGeometry().constructor.name).toBe("Point");
             expect(style[0].getImage().constructor.name).toBe("CircleStyle");
             expect(style[0].getText()).toBeNull();

--- a/packages/components/map/src/composables/openLayersFeatureStyles.spec.js
+++ b/packages/components/map/src/composables/openLayersFeatureStyles.spec.js
@@ -1,0 +1,142 @@
+// @vitest-environment happy-dom
+
+import { ref } from "vue";
+import { shallowMount } from "@vue/test-utils";
+import { describe, it, expect } from "vitest";
+import Feature from "ol/Feature.js";
+import Point from "ol/geom/Point.js";
+
+import { useOpenLayersFeatureStyles } from "./openLayersFeatureStyles.js";
+
+const coordinates = [9.254419, 50.102223];
+
+const createMapStub = ({ coordinate, pixel, zoom }) => {
+  return {
+    getPixelFromCoordinate: () => pixel || [10, 10],
+    getCoordinateFromPixel: () => coordinate || coordinates,
+    getView: () => ({
+      getZoom: () => zoom || 4,
+    }),
+  };
+};
+
+const component = {
+  template: `<div />`,
+  props: {
+    icon: {
+      type: Object,
+      default: null,
+    },
+    zoom: {
+      type: Number,
+      default: 4,
+    },
+  },
+  setup(props) {
+    const map = ref(createMapStub({ zoom: props.zoom }));
+
+    const icon = props.icon;
+
+    const { styleFeature } = useOpenLayersFeatureStyles({ icon, map });
+
+    return { map, styleFeature };
+  },
+};
+
+const factory = ({ props } = {}) =>
+  shallowMount(component, {
+    props,
+  });
+
+describe("@/composables/openLayersFeatureStyles.spec.js", () => {
+  describe("useOpenLayersFeatureStyles", () => {
+    describe("styleFeature", () => {
+      describe("single feature", () => {
+        const feature = new Feature({
+          features: [new Feature({ geometry: new Point(coordinates) })],
+        });
+
+        describe("when icon is supplied with src", () => {
+          const icon = {
+            src: "https://example.org/icons/location.svg",
+            width: 32,
+            height: 32,
+          };
+
+          it("styles point as an icon using that image", () => {
+            const wrapper = factory({ props: { icon } });
+
+            const styleFeature = wrapper.vm.styleFeature;
+            const style = styleFeature(feature);
+
+            expect(style.getImage().getSrc()).toBe(icon.src);
+            expect(style.getText()).toBeNull();
+          });
+        });
+
+        describe("when icon is not supplied", () => {
+          it("styles point as a circle", () => {
+            const wrapper = factory();
+
+            const styleFeature = wrapper.vm.styleFeature;
+            const style = styleFeature(feature);
+
+            expect(style.getImage().radius).toBe(14);
+            expect(style.getText().getText()).toBe("1");
+          });
+        });
+      });
+
+      describe("multiple features", () => {
+        const feature = new Feature({
+          features: [
+            new Feature({ geometry: new Point(coordinates) }),
+            new Feature({ geometry: new Point(coordinates) }),
+          ],
+        });
+
+        describe("at zoom levels below 16", () => {
+          const zoom = 15;
+
+          it("styles features clustered as a circle with number in text", () => {
+            const wrapper = factory({ props: { zoom } });
+
+            const styleFeature = wrapper.vm.styleFeature;
+            const style = styleFeature(feature);
+
+            expect(style.getImage().radius).toBe(14);
+            expect(style.getText().getText()).toBe("2");
+          });
+        });
+
+        describe("at zoom levels 16 and over", () => {
+          const zoom = 16;
+
+          it("styles features spread out from the cluster centre", async () => {
+            const wrapper = factory({ props: { zoom } });
+
+            const styleFeature = wrapper.vm.styleFeature;
+            const style = styleFeature(feature);
+
+            expect(style.length).toBe(5);
+            expect(style[0].getGeometry().constructor.name).toBe("Point");
+            expect(style[0].getImage().constructor.name).toBe("CircleStyle");
+            expect(style[0].getText()).toBeNull();
+            expect(style[1].getGeometry().constructor.name).toBe("Point");
+            expect(style[1].getImage().constructor.name).toBe("CircleStyle");
+            expect(style[1].getText().constructor.name).toBe("Text");
+            expect(style[2].getGeometry().constructor.name).toBe("LineString");
+            expect(style[2].getImage()).toBeNull();
+            expect(style[2].getText()).toBeNull();
+            expect(style[3].getGeometry().constructor.name).toBe("Point");
+            expect(style[3].getImage().constructor.name).toBe("CircleStyle");
+            expect(style[3].getText().constructor.name).toBe("Text");
+            expect(style[4].getGeometry().constructor.name).toBe("LineString");
+            expect(style[4].getImage()).toBeNull();
+            expect(style[4].getText()).toBeNull();
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/components/map/src/composables/openLayersMap.js
+++ b/packages/components/map/src/composables/openLayersMap.js
@@ -9,7 +9,6 @@ import { apply as applyMapboxStyle } from "ol-mapbox-style";
 import LayerGroup from "ol/layer/Group.js";
 
 const projection = "EPSG:3857";
-
 const centreOfEurope = [9.254419, 50.102223];
 
 export const useOpenLayersMap = ({

--- a/packages/components/map/src/composables/openLayersPointClusters.js
+++ b/packages/components/map/src/composables/openLayersPointClusters.js
@@ -2,6 +2,7 @@ import { computed, toRef, watchEffect } from "vue";
 
 import Feature from "ol/Feature.js";
 import Point from "ol/geom/Point.js";
+import LineString from "ol/geom/LineString.js";
 import VectorSource from "ol/source/Vector.js";
 import Cluster from "ol/source/Cluster.js";
 import VectorLayer from "ol/layer/Vector.js";
@@ -30,39 +31,90 @@ export const useOpenLayersPointClusters = ({
   );
 
   const clusterStyleCache = {};
+  if (pointIconSrc) {
+    clusterStyleCache[1] = new Style({
+      image: new Icon({
+        src: pointIconSrc,
+        width: 32,
+        height: 32,
+      }),
+    });
+  }
+
+  function degreesToRadians(degrees) {
+    return degrees * (Math.PI / 180);
+  }
+
   const clusterStyle = (feature) => {
     const features = feature.get("features");
-    const size = features.length;
+    const size = features?.length || 0;
+    const zoom = mapRef.value.getView().getZoom();
 
-    if (!clusterStyleCache[size]) {
-      if (pointIconSrc && size === 1) {
-        clusterStyleCache[size] = new Style({
-          image: new Icon({
-            src: pointIconSrc,
-            width: 32,
-            height: 32,
-          }),
-        });
-      } else {
-        clusterStyleCache[size] = new Style({
-          image: new CircleStyle({
-            radius: 14,
+    if (zoom >= 16 && size >= 2) {
+      const styles = features
+        .map((feature, index) => {
+          // a good distance from the original centre co-ordinates to a spread-out one,
+          // at zoom 16 is 0.000265625;
+          // as zoom increases, distance from centre needs to decrease
+          const distance = (0.000265625 * 16) / zoom;
+          const deltaAngle = (degreesToRadians(360) / size) * index;
+          const deltaX = distance * Math.sin(deltaAngle);
+          const deltaY = distance * Math.cos(deltaAngle);
+
+          const pointGeometry = feature.getGeometry().clone();
+          const originalCoordinates = pointGeometry.getCoordinates();
+          pointGeometry.translate(deltaX, deltaY);
+          const newCoordinates = pointGeometry.getCoordinates();
+          const pointStyle = clusterStyleCache[1].clone();
+          pointStyle.setGeometry(pointGeometry);
+
+          const lineStyle = new Style({
+            geometry: new LineString([originalCoordinates, newCoordinates]),
             stroke: new Stroke({
               color: "#000",
+              width: 2,
             }),
-            fill: new Fill({
-              color: "#000",
+          });
+
+          const circleStyle = new Style({
+            image: new CircleStyle({
+              radius: 4,
+              stroke: new Stroke({
+                color: "#000",
+              }),
+              fill: new Fill({
+                color: "#000",
+              }),
             }),
+            geometry: feature.getGeometry(),
+          });
+
+          return [pointStyle, lineStyle, circleStyle];
+        })
+        .flat();
+
+      return styles;
+    }
+
+    if (!clusterStyleCache[size]) {
+      clusterStyleCache[size] = new Style({
+        image: new CircleStyle({
+          radius: 14,
+          stroke: new Stroke({
+            color: "#000",
           }),
-          text: new Text({
-            text: size.toString(),
-            fill: new Fill({
-              color: "#fff",
-            }),
-            font: '700 0.875rem "Open Sans", "Arial", sans-serif',
+          fill: new Fill({
+            color: "#000",
           }),
-        });
-      }
+        }),
+        text: new Text({
+          text: size.toString(),
+          fill: new Fill({
+            color: "#fff",
+          }),
+          font: '700 0.875rem "Open Sans", "Arial", sans-serif',
+        }),
+      });
     }
 
     return clusterStyleCache[size];
@@ -71,8 +123,8 @@ export const useOpenLayersPointClusters = ({
   const createClustersLayer = () => {
     return new VectorLayer({
       source: new Cluster({
-        distance: Number.parseInt(40, 10),
-        minDistance: Number.parseInt(20, 10),
+        distance: 40,
+        minDistance: 20,
         source: new VectorSource({
           features: features.value,
         }),

--- a/packages/components/map/src/composables/openLayersPointClusters.js
+++ b/packages/components/map/src/composables/openLayersPointClusters.js
@@ -62,8 +62,6 @@ export const useOpenLayersPointClusters = ({
         isEqual,
       ).length === 1
     ) {
-      const coords = features.map((f) => f.getGeometry().getCoordinates());
-      console.log("clustered close coords", coords);
       const styles = features
         .map((feature, index) => {
           const pointGeometry = feature.getGeometry().clone();

--- a/packages/components/map/src/composables/openLayersPointClusters.js
+++ b/packages/components/map/src/composables/openLayersPointClusters.js
@@ -53,19 +53,24 @@ export const useOpenLayersPointClusters = ({
     if (zoom >= 16 && size >= 2) {
       const styles = features
         .map((feature, index) => {
-          // a good distance from the original centre co-ordinates to a spread-out one,
-          // at zoom 16 is 0.000265625;
-          // as zoom increases, distance from centre needs to decrease
-          const distance = (0.000265625 * 16) / zoom;
-          const deltaAngle = (degreesToRadians(360) / size) * index;
-          const deltaX = distance * Math.sin(deltaAngle);
-          const deltaY = distance * Math.cos(deltaAngle);
-
           const pointGeometry = feature.getGeometry().clone();
-          const originalCoordinates = pointGeometry.getCoordinates();
-          pointGeometry.translate(deltaX, deltaY);
-          const newCoordinates = pointGeometry.getCoordinates();
           const pointStyle = clusterStyleCache[1].clone();
+
+          const distance = 32; // pixels
+          const deltaAngle = (degreesToRadians(360) / size) * index;
+          const displacementX = distance * Math.sin(deltaAngle);
+          const displacementY = distance * Math.cos(deltaAngle);
+
+          const originalCoordinates = pointGeometry.getCoordinates();
+          const originalPixel =
+            mapRef.value.getPixelFromCoordinate(originalCoordinates);
+          const newPixel = [
+            originalPixel[0] + displacementX,
+            originalPixel[1] + displacementY,
+          ];
+          const newCoordinates = mapRef.value.getCoordinateFromPixel(newPixel);
+
+          pointGeometry.setCoordinates(newCoordinates);
           pointStyle.setGeometry(pointGeometry);
 
           const lineStyle = new Style({

--- a/packages/components/map/src/composables/openLayersPointClusters.js
+++ b/packages/components/map/src/composables/openLayersPointClusters.js
@@ -1,24 +1,18 @@
 import { computed, toRef, watchEffect } from "vue";
-// TODO: add to pkg deps
-import { uniqWith, isEqual } from "lodash-es";
 
 import Feature from "ol/Feature.js";
 import Point from "ol/geom/Point.js";
-import LineString from "ol/geom/LineString.js";
+
 import VectorSource from "ol/source/Vector.js";
 import Cluster from "ol/source/Cluster.js";
 import VectorLayer from "ol/layer/Vector.js";
-import CircleStyle from "ol/style/Circle.js";
-import Fill from "ol/style/Fill.js";
-import Icon from "ol/style/Icon.js";
-import Stroke from "ol/style/Stroke.js";
-import Style from "ol/style/Style.js";
-import Text from "ol/style/Text.js";
 
 export const useOpenLayersPointClusters = ({
   data,
+  distance,
+  minDistance,
   map,
-  pointIconSrc,
+  styleFeature,
 } = {}) => {
   const mapRef = toRef(map);
 
@@ -32,122 +26,17 @@ export const useOpenLayersPointClusters = ({
     ),
   );
 
-  const clusterStyleCache = {};
-  if (pointIconSrc) {
-    clusterStyleCache[1] = new Style({
-      image: new Icon({
-        src: pointIconSrc,
-        width: 32,
-        height: 32,
-      }),
-    });
-  }
-
-  function degreesToRadians(degrees) {
-    return degrees * (Math.PI / 180);
-  }
-
-  const clusterStyle = (feature) => {
-    const features = feature.get("features");
-    const size = features?.length || 0;
-    const zoom = mapRef.value.getView().getZoom();
-
-    // only break clusters apart at zoom level 16+, and if all features are
-    // at exactly the same co-ordinates
-    if (
-      zoom >= 16 &&
-      size >= 2 &&
-      uniqWith(
-        features.map((f) => f.getGeometry().getCoordinates()),
-        isEqual,
-      ).length === 1
-    ) {
-      const styles = features
-        .map((feature, index) => {
-          const pointGeometry = feature.getGeometry().clone();
-          const pointStyle = clusterStyleCache[1].clone();
-
-          const distance = 24; // pixels
-          const deltaAngle = (degreesToRadians(360) / size) * index;
-          const displacementX = distance * Math.sin(deltaAngle);
-          const displacementY = distance * Math.cos(deltaAngle);
-
-          const originalCoordinates = pointGeometry.getCoordinates();
-          const originalPixel =
-            mapRef.value.getPixelFromCoordinate(originalCoordinates);
-          const newPixel = [
-            originalPixel[0] + displacementX,
-            originalPixel[1] + displacementY,
-          ];
-          const newCoordinates = mapRef.value.getCoordinateFromPixel(newPixel);
-
-          pointGeometry.setCoordinates(newCoordinates);
-          pointStyle.setGeometry(pointGeometry);
-
-          const lineStyle = new Style({
-            geometry: new LineString([originalCoordinates, newCoordinates]),
-            stroke: new Stroke({
-              color: "#000",
-              width: 2,
-            }),
-          });
-
-          const circleStyle = new Style({
-            image: new CircleStyle({
-              radius: 4,
-              stroke: new Stroke({
-                color: "#000",
-              }),
-              fill: new Fill({
-                color: "#000",
-              }),
-            }),
-            geometry: feature.getGeometry(),
-          });
-
-          return [pointStyle, lineStyle, circleStyle];
-        })
-        .flat();
-
-      return styles;
-    }
-
-    if (!clusterStyleCache[size]) {
-      clusterStyleCache[size] = new Style({
-        image: new CircleStyle({
-          radius: 14,
-          stroke: new Stroke({
-            color: "#000",
-          }),
-          fill: new Fill({
-            color: "#000",
-          }),
-        }),
-        text: new Text({
-          text: size.toString(),
-          fill: new Fill({
-            color: "#fff",
-          }),
-          font: '700 0.875rem "Open Sans", "Arial", sans-serif',
-        }),
-      });
-    }
-
-    return clusterStyleCache[size];
-  };
-
   const createClustersLayer = () => {
     const clustersLayer = new VectorLayer({
       source: new Cluster({
-        distance: 48,
-        minDistance: 32,
+        distance,
+        minDistance,
         source: new VectorSource({
           features: features.value,
         }),
       }),
-      style: clusterStyle,
+      style: styleFeature,
     });
-    console.log("clustersLayer properties", clustersLayer.getProperties());
     return clustersLayer;
   };
 

--- a/packages/components/map/src/composables/openLayersPointClusters.js
+++ b/packages/components/map/src/composables/openLayersPointClusters.js
@@ -139,7 +139,7 @@ export const useOpenLayersPointClusters = ({
   const createClustersLayer = () => {
     const clustersLayer = new VectorLayer({
       source: new Cluster({
-        distance: 32,
+        distance: 48,
         minDistance: 32,
         source: new VectorSource({
           features: features.value,

--- a/packages/components/map/src/composables/openLayersPointClusters.js
+++ b/packages/components/map/src/composables/openLayersPointClusters.js
@@ -1,4 +1,6 @@
 import { computed, toRef, watchEffect } from "vue";
+// TODO: add to pkg deps
+import { uniqWith, isEqual } from "lodash-es";
 
 import Feature from "ol/Feature.js";
 import Point from "ol/geom/Point.js";
@@ -50,13 +52,24 @@ export const useOpenLayersPointClusters = ({
     const size = features?.length || 0;
     const zoom = mapRef.value.getView().getZoom();
 
-    if (zoom >= 16 && size >= 2) {
+    // only break clusters apart at zoom level 16+, and if all features are
+    // at exactly the same co-ordinates
+    if (
+      zoom >= 16 &&
+      size >= 2 &&
+      uniqWith(
+        features.map((f) => f.getGeometry().getCoordinates()),
+        isEqual,
+      ).length === 1
+    ) {
+      const coords = features.map((f) => f.getGeometry().getCoordinates());
+      console.log("clustered close coords", coords);
       const styles = features
         .map((feature, index) => {
           const pointGeometry = feature.getGeometry().clone();
           const pointStyle = clusterStyleCache[1].clone();
 
-          const distance = 32; // pixels
+          const distance = 24; // pixels
           const deltaAngle = (degreesToRadians(360) / size) * index;
           const displacementX = distance * Math.sin(deltaAngle);
           const displacementY = distance * Math.cos(deltaAngle);
@@ -126,16 +139,18 @@ export const useOpenLayersPointClusters = ({
   };
 
   const createClustersLayer = () => {
-    return new VectorLayer({
+    const clustersLayer = new VectorLayer({
       source: new Cluster({
-        distance: 40,
-        minDistance: 20,
+        distance: 32,
+        minDistance: 32,
         source: new VectorSource({
           features: features.value,
         }),
       }),
       style: clusterStyle,
     });
+    console.log("clustersLayer properties", clustersLayer.getProperties());
+    return clustersLayer;
   };
 
   const centreMapOnSinglePoint = () => {

--- a/packages/components/map/src/composables/openLayersPointClusters.spec.js
+++ b/packages/components/map/src/composables/openLayersPointClusters.spec.js
@@ -15,20 +15,20 @@ const elementId = "map";
 const component = {
   template: `<div id="${elementId}" />`,
   props: {
-    pointIconSrc: {
-      type: String,
+    icon: {
+      type: Object,
       default: null,
     },
   },
   setup(props) {
     const data = ref(null);
     const map = ref(null);
-    const pointIconSrc = props.pointIconSrc;
+    const icon = props.icon;
 
     useGeographic();
-    useOpenLayersPointClusters({ data, map, pointIconSrc });
+    useOpenLayersPointClusters({ data, map, icon });
 
-    return { data, map, pointIconSrc };
+    return { data, map, icon };
   },
 };
 
@@ -73,69 +73,7 @@ describe("@/composables/openLayersPointClusters.js", () => {
       });
 
       describe("styling", () => {
-        describe("single point", () => {
-          describe("when pointIconSrc is supplied", () => {
-            const pointIconSrc = "https://example.org/icons/location.svg";
-
-            it("styles point as an icon using that image", async () => {
-              const feature = {
-                get: () => ({ length: 1 }),
-              };
-              const wrapper = factory({ props: { pointIconSrc } });
-              wrapper.vm.map = new Map();
-              wrapper.vm.data = fixtures.onePointFeatureCollection;
-              await nextTick();
-
-              const map = wrapper.vm.map;
-              const layers = map.getLayers().getArray();
-              const clusterLayer = layers[0];
-              const style = clusterLayer.getStyleFunction()(feature);
-
-              expect(style.getImage().getSrc()).toBe(pointIconSrc);
-              expect(style.getText()).toBeNull();
-            });
-          });
-
-          describe("when pointIconSrc is not supplied", () => {
-            it("styles point as a circle", async () => {
-              const feature = {
-                get: () => ({ length: 1 }),
-              };
-              const wrapper = factory();
-              wrapper.vm.map = new Map();
-              wrapper.vm.data = fixtures.onePointFeatureCollection;
-              await nextTick();
-
-              const map = wrapper.vm.map;
-              const layers = map.getLayers().getArray();
-              const clusterLayer = layers[0];
-              const style = clusterLayer.getStyleFunction()(feature);
-
-              expect(style.getImage().radius).toBe(14);
-              expect(style.getText().getText()).toBe("1");
-            });
-          });
-        });
-
-        describe("multiple points", () => {
-          it("styles points as a circle", async () => {
-            const feature = {
-              get: () => ({ length: 2 }),
-            };
-            const wrapper = factory();
-            wrapper.vm.map = new Map();
-            wrapper.vm.data = fixtures.twoPointsFeatureCollection;
-            await nextTick();
-
-            const map = wrapper.vm.map;
-            const layers = map.getLayers().getArray();
-            const clusterLayer = layers[0];
-            const style = clusterLayer.getStyleFunction()(feature);
-
-            expect(style.getImage().radius).toBe(14);
-            expect(style.getText().getText()).toBe("2");
-          });
-        });
+        it("calls the supplied style fn");
       });
     });
   });

--- a/packages/layers/base/package.json
+++ b/packages/layers/base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@europeana/sea-base-layer",
   "type": "module",
-  "version": "0.1.2",
+  "version": "0.1.3-map.0",
   "main": "./nuxt.config.ts",
   "scripts": {
     "postinstall": "nuxt prepare"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ settings:
 
 catalogs:
   default:
+    lodash-es:
+      specifier: 4.18.1
+      version: 4.18.1
     node-fetch-native:
       specifier: 1.6.7
       version: 1.6.7
@@ -421,7 +424,7 @@ importers:
         specifier: 20.10.6
         version: 20.10.6
       lodash-es:
-        specifier: 4.18.1
+        specifier: 'catalog:'
         version: 4.18.1
       nuxt:
         specifier: catalog:nuxt3
@@ -437,7 +440,7 @@ importers:
         version: 12.2.0
       unplugin-vue-components:
         specifier: 32.1.0
-        version: 32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(vue@3.5.38(typescript@5.9.3))
+        version: 32.1.0(@nuxt/kit@3.21.8(magicast@0.5.3))(vue@3.5.38(typescript@5.9.3))
       vue:
         specifier: catalog:vue3
         version: 3.5.38(typescript@5.9.3)
@@ -450,6 +453,9 @@ importers:
       '@vueuse/core':
         specifier: catalog:vue3
         version: 14.3.0(vue@3.5.38(typescript@5.9.3))
+      lodash-es:
+        specifier: 'catalog:'
+        version: 4.18.1
       ol:
         specifier: 'catalog:'
         version: 10.9.0
@@ -4480,6 +4486,7 @@ packages:
   conventional-changelog-core@5.0.1:
     resolution: {integrity: sha512-Rvi5pH+LvgsqGwZPZ3Cq/tz4ty7mjijhr3qR4m9IBXNbxGGYgTVVO+duXzz9aArmHxFtwZ+LRkrNIMDQzgoY4A==}
     engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-preset-loader@3.0.0:
     resolution: {integrity: sha512-qy9XbdSLmVnwnvzEisjxdDiLA4OmV3o8db+Zdg4WiFw14fP3B6XNz98X0swPPpkTd/pc1K7+adKgEDM1JCUMiA==}
@@ -5388,12 +5395,13 @@ packages:
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -5403,7 +5411,7 @@ packages:
   git-semver-tags@5.0.1:
     resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -8502,6 +8510,9 @@ packages:
   vue-component-type-helpers@3.3.5:
     resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
 
+  vue-component-type-helpers@3.3.6:
+    resolution: {integrity: sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==}
+
   vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
 
@@ -11467,7 +11478,7 @@ snapshots:
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       type-fest: 2.19.0
       vue: 3.5.38(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.5
+      vue-component-type-helpers: 3.3.6
 
   '@stylistic/eslint-plugin@5.10.0(eslint@10.5.0(jiti@2.7.0))':
     dependencies:
@@ -17014,7 +17025,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.4
 
-  unplugin-vue-components@32.1.0(@nuxt/kit@4.4.8(magicast@0.5.3))(vue@3.5.38(typescript@5.9.3)):
+  unplugin-vue-components@32.1.0(@nuxt/kit@3.21.8(magicast@0.5.3))(vue@3.5.38(typescript@5.9.3)):
     dependencies:
       chokidar: 5.0.0
       local-pkg: 1.2.1
@@ -17027,7 +17038,7 @@ snapshots:
       unplugin-utils: 0.3.1
       vue: 3.5.38(typescript@5.9.3)
     optionalDependencies:
-      '@nuxt/kit': 4.4.8(magicast@0.5.3)
+      '@nuxt/kit': 3.21.8(magicast@0.5.3)
 
   unplugin-vue-router@0.12.0(vue-router@4.6.4(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3)):
     dependencies:
@@ -17350,6 +17361,8 @@ snapshots:
   vue-component-type-helpers@2.2.12: {}
 
   vue-component-type-helpers@3.3.5: {}
+
+  vue-component-type-helpers@3.3.6: {}
 
   vue-devtools-stub@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ allowBuilds:
   nx: true
   unrs-resolver: true
 catalog:
+  lodash-es: "4.18.1"
   node-fetch-native: "1.6.7"
   ol: "10.9.0"
 catalogs:


### PR DESCRIPTION
- mv OpenLayers styling into new composable `useOpenLayersFeatureStyles`
- at zoom levels >= 16, break apart clusters where all points have identical co-ordinates
  - mark the centre point with a circle
  - move the point markers away from the centre point at different angles
  - connect the point markers to the centre point by lines