### PR TITLE
feat(map): add popover overlay support

### DIFF
--- a/packages/components/map/README.md
+++ b/packages/components/map/README.md
@@ -6,6 +6,11 @@ Vue 3 component/app to show a map on which clustered points may be displayed.
 
 TODO
 
+### Popover
+
+To use the popover feature pass in the `pinPopover` prop with an existing HTML element.
+When single points are clicked a `change:activefeature` event with a `activeFeatureName` prop is dispatched on the map instance. This can be used, for exampe, to set the relevant popover content.
+
 ## License
 
 Licensed under the [EUPL v1.2](../../../LICENSE.md).

--- a/packages/components/map/index.html
+++ b/packages/components/map/index.html
@@ -20,7 +20,7 @@
       id="popover"
       style="background-color: white; padding: 1rem; margin: 0.2rem"
     >
-      Pover content
+      Popover content
     </div>
     <script type="module">
       import EuropeanaMap from "./src/index.js";
@@ -30,8 +30,7 @@
         // json: JSON.stringify({ features: [{type:'Feature',id:'http://data.europeana.eu/organization/1',geometry:{type:'Point',coordinates:[18.2924425,57.6396512]}}]}),
         url: "https://www.europeana.eu/_api/collections/organisations/geo",
         hash: true,
-        // Uncomment for popover testing
-        // pinPopover: document.getElementById('popover')
+        pinPopover: document.getElementById("popover"),
       });
     </script>
   </body>

--- a/packages/components/map/index.html
+++ b/packages/components/map/index.html
@@ -16,12 +16,22 @@
       }
     </style>
     <div id="europeana-map" />
+    <div
+      id="popover"
+      style="background-color: white; padding: 1rem; margin: 0.2rem"
+    >
+      Pover content
+    </div>
     <script type="module">
       import EuropeanaMap from "./src/index.js";
 
       new EuropeanaMap("#europeana-map", {
+        // Uncomment for single feature testing
+        // json: JSON.stringify({ features: [{type:'Feature',id:'http://data.europeana.eu/organization/1',geometry:{type:'Point',coordinates:[18.2924425,57.6396512]}}]}),
         url: "https://www.europeana.eu/_api/collections/organisations/geo",
         hash: true,
+        // Uncomment for popover testing
+        // pinPopover: document.getElementById('popover')
       });
     </script>
   </body>

--- a/packages/components/map/src/components/EuropeanaMap.vue
+++ b/packages/components/map/src/components/EuropeanaMap.vue
@@ -24,6 +24,10 @@ const props = defineProps({
     type: String,
     default: null,
   },
+  pinPopover: {
+    type: Object,
+    default: null,
+  },
   style: {
     type: [Object, String],
     default: null,
@@ -43,6 +47,9 @@ const data = ref(null);
 const centre = computed(() => props.centre || injectedConfig?.value?.centre);
 const hash = computed(() => props.hash || injectedConfig?.value?.hash);
 const json = computed(() => props.json || injectedConfig?.value?.json);
+const pinPopover = computed(
+  () => props.pinPopover || injectedConfig?.value?.pinPopover,
+);
 const style = computed(() => props.style || injectedConfig?.value?.style);
 const url = computed(() => props.url || injectedConfig?.value?.url);
 const zoom = computed(() => props.zoom || injectedConfig?.value?.zoom);
@@ -83,6 +90,7 @@ useOpenLayersPointsVectorLayer({
   distance: singleFeatureStyleMinDimension * 1.5,
   minDistance: singleFeatureStyleMinDimension * 0.75,
   map,
+  pinPopover,
   styleFeature,
 });
 </script>

--- a/packages/components/map/src/composables/openLayersPointsVectorLayer.js
+++ b/packages/components/map/src/composables/openLayersPointsVectorLayer.js
@@ -1,11 +1,11 @@
-import { computed, toRef, watchEffect } from "vue";
+import { computed, ref, toRef, watchEffect } from "vue";
 
-import Feature from "ol/Feature.js";
-import Point from "ol/geom/Point.js";
-
-import VectorSource from "ol/source/Vector.js";
 import Cluster from "ol/source/Cluster.js";
+import Feature from "ol/Feature.js";
+import Overlay from "ol/Overlay.js";
+import Point from "ol/geom/Point.js";
 import VectorLayer from "ol/layer/Vector.js";
+import VectorSource from "ol/source/Vector.js";
 import { boundingExtent } from "ol/extent.js";
 
 export const useOpenLayersPointsVectorLayer = ({
@@ -13,9 +13,12 @@ export const useOpenLayersPointsVectorLayer = ({
   distance,
   minDistance,
   map,
+  pinPopover,
   styleFeature,
 } = {}) => {
   const mapRef = toRef(map);
+  // TODO: split out popover to  separate composable?
+  const popoverOverlay = ref(null);
 
   const features = computed(() =>
     data.value.features.map(
@@ -50,6 +53,18 @@ export const useOpenLayersPointsVectorLayer = ({
     });
   };
 
+  const createPopoverOverlay = () => {
+    popoverOverlay.value = new Overlay({
+      element: pinPopover.value,
+      autoPan: {
+        animation: {
+          duration: 250,
+        },
+      },
+    });
+    mapRef.value?.addOverlay(popoverOverlay.value);
+  };
+
   const centreMapOnSinglePoint = () => {
     if (data.value?.features?.length === 1) {
       mapRef.value
@@ -66,7 +81,14 @@ export const useOpenLayersPointsVectorLayer = ({
         centreMapOnSinglePoint();
       } else {
         mapRef.value.addLayer(createClustersLayer());
+      }
 
+      if (pinPopover.value && !popoverOverlay.value) {
+        createPopoverOverlay();
+      }
+
+      // Pins are clickable when there are clusters and/or popover
+      if (data.value?.features?.length > 1 || pinPopover.value) {
         mapRef.value?.on("click", handleClick);
       }
     }
@@ -74,7 +96,26 @@ export const useOpenLayersPointsVectorLayer = ({
 
   function handleClick(e) {
     const clickedFeatures = mapRef.value.getFeaturesAtPixel(e.pixel);
-    const features = clickedFeatures[0]?.get("features");
+    // Get clustered or single point feature(s)
+    const features = clickedFeatures[0]?.get("features") || clickedFeatures;
+
+    // Show popover when single point
+    if (features?.length === 1 && popoverOverlay.value) {
+      const feature = features[0];
+      const activeFeatureName = feature.get("name");
+
+      // Dispatch custom event the parent app can listen too
+      mapRef.value.dispatchEvent({
+        type: "change:activefeature",
+        activeFeatureName,
+      });
+
+      const coordinates = feature.getGeometry().getCoordinates();
+      popoverOverlay.value.setPosition(coordinates);
+    } else {
+      // Hide popover when clicked anywhere else
+      popoverOverlay.value?.setPosition(undefined);
+    }
 
     if (features?.length > 1) {
       const extent = boundingExtent(

--- a/packages/components/map/src/composables/openLayersPointsVectorLayer.spec.js
+++ b/packages/components/map/src/composables/openLayersPointsVectorLayer.spec.js
@@ -3,9 +3,10 @@
 import { shallowMount } from "@vue/test-utils";
 import { describe, it, expect, vi } from "vitest";
 import { nextTick, ref } from "vue";
-import Map from "ol/Map.js";
-import VectorLayer from "ol/layer/Vector.js";
 import Cluster from "ol/source/Cluster.js";
+import Map from "ol/Map.js";
+import Overlay from "ol/Overlay.js";
+import VectorLayer from "ol/layer/Vector.js";
 import { useGeographic } from "ol/proj.js";
 
 import { useOpenLayersPointsVectorLayer } from "./openLayersPointsVectorLayer.js";
@@ -13,7 +14,7 @@ import { fixtures } from "@test/fixtures.js";
 
 const elementId = "map";
 const component = {
-  template: `<div id="${elementId}" />`,
+  template: `<div id="${elementId}" /><div id="popover"/>`,
   props: {
     icon: {
       type: Object,
@@ -24,11 +25,12 @@ const component = {
     const data = ref(null);
     const map = ref(null);
     const icon = props.icon;
+    const pinPopover = ref(null);
 
     useGeographic();
-    useOpenLayersPointsVectorLayer({ data, map, icon });
+    useOpenLayersPointsVectorLayer({ data, map, icon, pinPopover });
 
-    return { data, map, icon };
+    return { data, map, icon, pinPopover };
   },
 };
 
@@ -69,6 +71,61 @@ describe("@/composables/openLayersPointsVectorLayer.js", () => {
           expect(map.getView().getCenter()).toEqual(
             fixtures.onePointFeatureCollection.features[0].geometry.coordinates,
           );
+        });
+
+        describe("and popover element is present", () => {
+          it("adds Overlay for popover content", async () => {
+            const wrapper = factory();
+            wrapper.vm.map = new Map();
+            wrapper.vm.data = fixtures.onePointFeatureCollection;
+            wrapper.vm.pinPopover = wrapper.find("#popover").element;
+            await nextTick();
+
+            const map = wrapper.vm.map;
+            const overlays = map.getOverlays().getArray();
+            expect(overlays).toHaveLength(1);
+            expect(overlays[0]).toBeInstanceOf(Overlay);
+          });
+
+          describe("and a point is clicked", () => {
+            it("dispatches change:activefeature event and sets overlay position", async () => {
+              const wrapper = factory();
+              wrapper.vm.map = new Map();
+              wrapper.vm.data = fixtures.onePointFeatureCollection;
+              wrapper.vm.pinPopover = wrapper.find("#popover").element;
+              await nextTick();
+
+              const map = wrapper.vm.map;
+              const dispatchEventSpy = vi.spyOn(map, "dispatchEvent");
+              const name = "feature name";
+
+              vi.spyOn(map, "getFeaturesAtPixel").mockReturnValue([
+                {
+                  get: () => [
+                    {
+                      getGeometry: () => ({
+                        getCoordinates: () => [0, 0],
+                      }),
+                      get: () => name,
+                    },
+                  ],
+                },
+              ]);
+
+              const overlay = map.getOverlays().getArray()[0];
+              const setPositionSpy = vi.spyOn(overlay, "setPosition");
+
+              await map.dispatchEvent({
+                type: "click",
+              });
+
+              expect(dispatchEventSpy).toHaveBeenCalledWith({
+                type: "change:activefeature",
+                activeFeatureName: name,
+              });
+              expect(setPositionSpy).toHaveBeenCalled();
+            });
+          });
         });
       });
 


### PR DESCRIPTION
- Introduces new `pinPopover` prop, which expects a ref to an HTML element
- When a value is passed to the `pinPopover` prop, there is an overlay added to the map
- On single point map clicks, a custom  event is dispatched (for a parent element to listen to) and the overlay position is so to the clicked point coordinate.
- Adds some testing capabilities to the index.html so this can be locally tested
- Adds some docs to the README wrt the popover feature