### PR TITLE
chore(map): disable rotation interactions

### DIFF
--- a/packages/components/map/src/composables/openLayersMap.js
+++ b/packages/components/map/src/composables/openLayersMap.js
@@ -3,6 +3,7 @@ import { onMounted, toRef, unref, watch } from "vue";
 import Map from "ol/Map.js";
 import View from "ol/View.js";
 
+import { defaults as defaultInteractions } from "ol/interaction/defaults.js";
 import TileLayer from "ol/layer/Tile.js";
 import OSM from "ol/source/OSM.js";
 import { useGeographic } from "ol/proj.js";
@@ -11,6 +12,17 @@ import LayerGroup from "ol/layer/Group.js";
 
 const projection = "EPSG:3857";
 const centreOfEurope = [9.254419, 50.102223];
+
+export const createOpenLayersMap = () => {
+  return new Map({
+    controls: [],
+    interactions: defaultInteractions({
+      altShiftDragRotate: false,
+      pinchRotate: false,
+    }),
+    keyboardEventTarget: "map-keyboard-toggle",
+  });
+};
 
 export const useOpenLayersMap = ({
   centre,
@@ -83,10 +95,7 @@ export const useOpenLayersMap = ({
 
   const initMap = () => {
     if (!mapRef.value) {
-      mapRef.value = new Map({
-        controls: [],
-        keyboardEventTarget: "map-keyboard-toggle",
-      });
+      mapRef.value = createOpenLayersMap();
     }
 
     mapRef.value.setTarget(targetRef.value);

--- a/packages/components/map/src/composables/openLayersMap.spec.js
+++ b/packages/components/map/src/composables/openLayersMap.spec.js
@@ -5,7 +5,7 @@ import { shallowMount } from "@vue/test-utils";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import OpenLayersMap from "ol/Map.js";
 
-import { useOpenLayersMap } from "./openLayersMap.js";
+import { createOpenLayersMap, useOpenLayersMap } from "./openLayersMap.js";
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
@@ -56,6 +56,34 @@ describe("@/composables/openLayersMap.js", () => {
   });
   afterAll(() => {
     vi.restoreAllMocks();
+  });
+
+  describe("createOpenLayersMap", () => {
+    it("returns a new instance of OpenLayers Map class", () => {
+      const map = createOpenLayersMap();
+
+      expect(map.constructor.name).toBe("Map");
+    });
+
+    it("has no controls by default", () => {
+      const map = createOpenLayersMap();
+
+      const controlsCount = map.getControls().getLength();
+
+      expect(controlsCount).toBe(0);
+    });
+
+    it("disables rotation interactions", () => {
+      const map = createOpenLayersMap();
+
+      const interactions = map
+        .getInteractions()
+        .getArray()
+        .map((interaction) => interaction.constructor.name);
+
+      expect(interactions.includes("DragRotate")).toBe(false);
+      expect(interactions.includes("PinchRotate")).toBe(false);
+    });
   });
 
   describe("useOpenLayersMap", () => {

--- a/packages/components/map/src/index.js
+++ b/packages/components/map/src/index.js
@@ -1,7 +1,8 @@
 import { createApp, computed, reactive } from "vue";
-import OpenLayersMap from "ol/Map.js";
 
+import { createOpenLayersMap } from "@/composables/openLayersMap.js";
 import EuropeanaMapComponent from "@/components/EuropeanaMap.vue";
+
 export { EuropeanaMapComponent };
 
 export class EuropeanaMapWrapper {
@@ -10,10 +11,7 @@ export class EuropeanaMapWrapper {
   #config = reactive({});
 
   constructor(target, options = {}) {
-    this.#olMap = new OpenLayersMap({
-      controls: [],
-      keyboardEventTarget: "map-keyboard-toggle",
-    });
+    this.#olMap = createOpenLayersMap();
 
     for (const prop in EuropeanaMapComponent.props) {
       this.#config[prop] = options[prop];


### PR DESCRIPTION
- adds a `createOpenLayersMap` function to `openLayersMap` composable module, which is used there and also in the wrapper class `EuropeanaMapWrapper`, to reduce code duplication and serve as a SSOT for map defaults
- removes rotation interactions from the map interactions, via that new function
