### PR TITLE
refactor(map): create useLocationHash composable

### DIFF
--- a/packages/components/map/src/components/EuropeanaMap.vue
+++ b/packages/components/map/src/components/EuropeanaMap.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, ref, inject } from "vue";
 import { useFetch } from "@vueuse/core";
 import "ol/ol.css";
 
+import { useLocationHash } from "@/composables/locationHash.js";
 import { useOpenLayersMap } from "@/composables/openLayersMap.js";
 import { useOpenLayersPointsVectorLayer } from "@/composables/openLayersPointsVectorLayer.js";
 import { useOpenLayersFeatureStyles } from "@/composables/openLayersFeatureStyles.js";
@@ -59,7 +60,7 @@ const props = defineProps({
 
 const data = ref(null);
 
-const centre = computed(() => props.centre || injectedConfig?.value?.centre);
+const centre = ref(props.centre || injectedConfig?.value?.centre);
 // TODO: set some defaults, deep merged with supplied?
 const controls = computed(
   () => props.controls || injectedConfig?.value?.controls,
@@ -74,7 +75,7 @@ const pinPopover = computed(
 );
 const style = computed(() => props.style || injectedConfig?.value?.style);
 const url = computed(() => props.url || injectedConfig?.value?.url);
-const zoom = computed(() => props.zoom || injectedConfig?.value?.zoom);
+const zoom = ref(props.zoom || injectedConfig?.value?.zoom);
 
 if (json.value) {
   data.value = JSON.parse(json.value);
@@ -94,10 +95,13 @@ const icon = {
   height: 24,
 };
 
+if (hash.value) {
+  useLocationHash({ centre, elementId, map, zoom });
+}
+
 useOpenLayersMap({
   centre,
   elementId,
-  hash,
   map,
   style,
   zoom,

--- a/packages/components/map/src/components/EuropeanaMap.vue
+++ b/packages/components/map/src/components/EuropeanaMap.vue
@@ -96,7 +96,7 @@ const icon = {
 };
 
 if (hash.value) {
-  useLocationHash({ centre, elementId, map, zoom });
+  useLocationHash({ centre, elementId, zoom });
 }
 
 useOpenLayersMap({

--- a/packages/components/map/src/composables/locationHash.js
+++ b/packages/components/map/src/composables/locationHash.js
@@ -1,0 +1,47 @@
+import { onMounted, toRef, watch } from "vue";
+
+export const useLocationHash = ({ centre, elementId, zoom }) => {
+  const centreRef = toRef(centre);
+  const elementIdRef = toRef(elementId);
+  const zoomRef = toRef(zoom);
+
+  const initFromHash = () => {
+    if (window.location.hash) {
+      const hashParams = new URLSearchParams(window.location.hash.slice(1));
+      const hashId = hashParams.get("em-id");
+      if (hashId !== elementIdRef.value) {
+        // there may be multiple maps on the page, but only 1 active & tracked via the URL hash
+        return;
+      }
+      const hashCentre = hashParams.get("em-c");
+      const hashZoom = hashParams.get("em-z");
+
+      if (hashCentre) {
+        centreRef.value = hashCentre.split(",").map(Number);
+      }
+      if (hashZoom) {
+        zoomRef.value = Number(hashZoom);
+      }
+      if (hashCentre || hashZoom) {
+        document.getElementById(elementIdRef.value)?.scrollIntoView();
+      }
+    }
+  };
+
+  const updateLocationHash = () => {
+    const hashParams = new URLSearchParams({
+      "em-id": elementIdRef.value,
+      "em-c": centreRef.value?.join(","),
+      "em-z": zoomRef.value,
+    }).toString();
+    const url = new URL(window.location);
+    url.hash = `#${hashParams}`;
+
+    window.location.replace(url);
+  };
+
+  onMounted(() => {
+    initFromHash();
+    watch([centreRef, zoomRef], updateLocationHash);
+  });
+};

--- a/packages/components/map/src/composables/locationHash.spec.js
+++ b/packages/components/map/src/composables/locationHash.spec.js
@@ -1,0 +1,71 @@
+// @vitest-environment happy-dom
+
+import { ref, nextTick } from "vue";
+import { shallowMount } from "@vue/test-utils";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { useLocationHash } from "./locationHash.js";
+
+const component = {
+  template: `<div />`,
+  props: {
+    centre: {
+      type: Array,
+      default: null,
+    },
+    elementId: {
+      type: String,
+      default: "map",
+    },
+    zoom: {
+      type: Number,
+      default: null,
+    },
+  },
+  setup(props) {
+    const centre = ref(props.centre);
+    const elementId = props.elementId;
+    const zoom = ref(props.zoom);
+
+    useLocationHash({ centre, elementId, zoom });
+
+    return { centre, zoom };
+  },
+};
+
+const factory = ({ props } = {}) =>
+  shallowMount(component, {
+    props,
+  });
+
+describe("@/composables/locationHash.js", () => {
+  describe("useLocationHash", () => {
+    afterEach(() => {
+      window.location.hash = undefined;
+    });
+
+    it("reads centre and zoom from window.location.hash", () => {
+      window.location.hash = "#em-id=map&em-z=5&em-c=-5%2C36";
+      const wrapper = factory();
+
+      const centre = wrapper.vm.centre;
+      const zoom = wrapper.vm.zoom;
+
+      expect(centre).toEqual([-5, 36]);
+      expect(zoom).toBe(5);
+    });
+
+    it("updates hash when centre/zoom change", async () => {
+      const centre = [-5, 36];
+      const zoom = 5;
+      const wrapper = factory();
+
+      wrapper.vm.zoom = zoom;
+      wrapper.vm.centre = centre;
+
+      await nextTick();
+
+      expect(window.location.hash).toBe("#em-id=map&em-c=-5%2C36&em-z=5");
+    });
+  });
+});

--- a/packages/components/map/src/composables/openLayersMap.js
+++ b/packages/components/map/src/composables/openLayersMap.js
@@ -1,4 +1,4 @@
-import { onMounted, toRef, unref, watch } from "vue";
+import { onMounted, toRef, watch } from "vue";
 
 import Map from "ol/Map.js";
 import View from "ol/View.js";
@@ -28,19 +28,22 @@ export const createOpenLayersMap = (elementId) => {
 export const useOpenLayersMap = ({
   centre,
   elementId,
-  hash,
   map,
   style,
   zoom,
 } = {}) => {
-  // unref first in case it's a computed and we need to set it
-  const centreRef = toRef(unref(centre) || centreOfEurope);
-  const hashRef = toRef(hash);
+  const centreRef = toRef(centre);
   const elementIdRef = toRef(elementId);
   const mapRef = toRef(map);
   const styleRef = toRef(style);
-  // unref first in case it's a computed and we need to set it
-  const zoomRef = toRef(unref(zoom) || 4);
+  const zoomRef = toRef(zoom);
+
+  if (!centreRef.value) {
+    centreRef.value = centreOfEurope;
+  }
+  if (!zoomRef.value) {
+    zoomRef.value = 4;
+  }
 
   // use Geographic projection for correct position of geo coordinates
   useGeographic();
@@ -65,43 +68,6 @@ export const useOpenLayersMap = ({
     });
   };
 
-  // TODO: mv hash init/track to own composable
-  const initFromHash = () => {
-    if (window.location.hash) {
-      const hashParams = new URLSearchParams(window.location.hash.slice(1));
-      const hashId = hashParams.get("em-id");
-      if (hashId !== elementIdRef.value) {
-        // there may be multiple maps on the page, but only 1 active & tracked via the URL hash
-        return;
-      }
-      const hashCentre = hashParams.get("em-c");
-      const hashZoom = hashParams.get("em-z");
-
-      if (hashCentre) {
-        centreRef.value = hashCentre.split(",").map(Number);
-      }
-      if (hashZoom) {
-        zoomRef.value = Number(hashZoom);
-      }
-      if (hashCentre || hashZoom) {
-        document.getElementById(elementIdRef.value)?.scrollIntoView();
-      }
-    }
-  };
-
-  const trackInHash = () => {
-    const url = new URL(window.location);
-    const hashCentre = mapRef.value.getView().getCenter().join(",");
-    const hashZoom = mapRef.value.getView().getZoom();
-    const hashParams = new URLSearchParams({
-      "em-id": elementIdRef.value,
-      "em-c": hashCentre,
-      "em-z": hashZoom,
-    }).toString();
-    url.hash = `#${hashParams}`;
-    window.location.replace(url);
-  };
-
   const applyStyle = () =>
     mapRef.value?.setLayers([createLayer()].filter(Boolean));
 
@@ -112,22 +78,27 @@ export const useOpenLayersMap = ({
 
     mapRef.value.setTarget(elementIdRef.value);
     mapRef.value.setView(createView());
+    registerMapEventHandler();
     applyStyle();
-
-    if (hashRef.value) {
-      // prevent moveend callback firing during initial rendering which we don't want
-      mapRef.value.once("loadend", () => {
-        mapRef.value.on("moveend", trackInHash);
-      });
-    }
   };
 
   watch(styleRef, applyStyle, { immediate: true });
 
+  const updateRefsFromMapView = () => {
+    centreRef.value = mapRef.value.getView().getCenter();
+    zoomRef.value = mapRef.value.getView().getZoom();
+  };
+
+  const registerMapEventHandler = () => {
+    // prevent moveend callback firing during initial rendering which we don't want
+    mapRef.value.once("loadend", () => {
+      mapRef.value.on("moveend", () => {
+        updateRefsFromMapView();
+      });
+    });
+  };
+
   onMounted(() => {
-    if (hashRef.value) {
-      initFromHash();
-    }
     initMap();
   });
 

--- a/packages/components/map/src/composables/openLayersMap.spec.js
+++ b/packages/components/map/src/composables/openLayersMap.spec.js
@@ -222,17 +222,6 @@ describe("@/composables/openLayersMap.js", () => {
         });
       });
 
-      // it("updates hash with centre and zoom on moveend event (after loadend event)", () => {
-
-      //   const wrapper = factory({ props: { centre, hash, zoom } });
-
-      //   const map = wrapper.vm.map;
-      //   map.dispatchEvent("loadend");
-      //   map.dispatchEvent("moveend");
-
-      //   expect(window.location.hash).toBe("#em-id=map&em-c=-5%2C36&em-z=5");
-      // });
-
       describe("moveend event listener", () => {
         const centre = [-5, 36];
         const zoom = 5;
@@ -271,48 +260,5 @@ describe("@/composables/openLayersMap.js", () => {
         });
       });
     });
-
-    //   describe("hash", () => {
-    //     afterEach(() => {
-    //       window.location.hash = undefined;
-    //     });
-
-    //     describe("when `true`", () => {
-    //       const hash = true;
-
-    //       it("reads centre and zoom from window.location.hash", () => {
-    //         window.location.hash = "#em-id=map&em-z=5&em-c=-5%2C36";
-    //         const wrapper = factory({ props: { hash } });
-
-    //         const map = wrapper.vm.map;
-
-    //         expect(map.getView().getCenter()).toEqual([-5, 36]);
-    //         expect(map.getView().getZoom()).toBe(5);
-    //       });
-    //     });
-
-    //     describe("when `false` (default)", () => {
-    //       it("ignores centre and zoom from window.location.hash", () => {
-    //         window.location.hash = "#em-id=map&em-z=5&em-c=-5%2C36";
-    //         const wrapper = factory();
-
-    //         const map = wrapper.vm.map;
-
-    //         expect(map.getView().getCenter()).not.toEqual([-5, 36]);
-    //         expect(map.getView().getZoom()).not.toBe(5);
-    //       });
-
-    //       it("does not update hash with centre and zoom on moveend event", () => {
-    //         const centre = [-5, 36];
-    //         const zoom = 5;
-    //         const wrapper = factory({ props: { centre, zoom } });
-
-    //         const map = wrapper.vm.map;
-    //         map.dispatchEvent("moveend");
-
-    //         expect(window.location.hash).not.toBe("#c=-5%2C36&z=5");
-    //       });
-    //     });
-    //   });
   });
 });

--- a/packages/components/map/src/composables/openLayersMap.spec.js
+++ b/packages/components/map/src/composables/openLayersMap.spec.js
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { nextTick } from "vue";
+import { nextTick, ref } from "vue";
 import { shallowMount } from "@vue/test-utils";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import OpenLayersMap from "ol/Map.js";
@@ -40,8 +40,16 @@ const component = {
     },
   },
   setup(props) {
-    const { map } = useOpenLayersMap(props);
-    return { map };
+    const centre = ref(props.centre);
+    const zoom = ref(props.zoom);
+
+    const { map } = useOpenLayersMap({
+      ...props,
+      centre,
+      zoom,
+    });
+
+    return { centre, map, zoom };
   },
 };
 
@@ -213,61 +221,98 @@ describe("@/composables/openLayersMap.js", () => {
           });
         });
       });
-    });
 
-    describe("hash", () => {
-      afterEach(() => {
-        window.location.hash = undefined;
-      });
+      // it("updates hash with centre and zoom on moveend event (after loadend event)", () => {
 
-      describe("when `true`", () => {
-        const hash = true;
+      //   const wrapper = factory({ props: { centre, hash, zoom } });
 
-        it("reads centre and zoom from window.location.hash", () => {
-          window.location.hash = "#em-id=map&em-z=5&em-c=-5%2C36";
-          const wrapper = factory({ props: { hash } });
+      //   const map = wrapper.vm.map;
+      //   map.dispatchEvent("loadend");
+      //   map.dispatchEvent("moveend");
 
-          const map = wrapper.vm.map;
+      //   expect(window.location.hash).toBe("#em-id=map&em-c=-5%2C36&em-z=5");
+      // });
 
-          expect(map.getView().getCenter()).toEqual([-5, 36]);
-          expect(map.getView().getZoom()).toBe(5);
+      describe("moveend event listener", () => {
+        const centre = [-5, 36];
+        const zoom = 5;
+
+        describe("before loadend event", () => {
+          it("does not update centre and zoom ref values", async () => {
+            const wrapper = factory();
+
+            const map = wrapper.vm.map;
+            map.getView().setCenter(centre);
+            map.getView().setZoom(zoom);
+            map.dispatchEvent("moveend");
+
+            await nextTick();
+
+            expect(wrapper.vm.zoom).not.toBe(zoom);
+            expect(wrapper.vm.centre).not.toEqual(centre);
+          });
         });
 
-        it("updates hash with centre and zoom on moveend event (after loadend event)", () => {
-          const centre = [-5, 36];
-          const zoom = 5;
-          const wrapper = factory({ props: { centre, hash, zoom } });
+        describe("after loadend event", () => {
+          it("updates centre and zoom ref values", async () => {
+            const wrapper = factory();
 
-          const map = wrapper.vm.map;
-          map.dispatchEvent("loadend");
-          map.dispatchEvent("moveend");
+            const map = wrapper.vm.map;
+            map.getView().setCenter(centre);
+            map.getView().setZoom(zoom);
+            map.dispatchEvent("loadend");
+            map.dispatchEvent("moveend");
 
-          expect(window.location.hash).toBe("#em-id=map&em-c=-5%2C36&em-z=5");
-        });
-      });
+            await nextTick();
 
-      describe("when `false` (default)", () => {
-        it("ignores centre and zoom from window.location.hash", () => {
-          window.location.hash = "#em-id=map&em-z=5&em-c=-5%2C36";
-          const wrapper = factory();
-
-          const map = wrapper.vm.map;
-
-          expect(map.getView().getCenter()).not.toEqual([-5, 36]);
-          expect(map.getView().getZoom()).not.toBe(5);
-        });
-
-        it("does not update hash with centre and zoom on moveend event", () => {
-          const centre = [-5, 36];
-          const zoom = 5;
-          const wrapper = factory({ props: { centre, zoom } });
-
-          const map = wrapper.vm.map;
-          map.dispatchEvent("moveend");
-
-          expect(window.location.hash).not.toBe("#c=-5%2C36&z=5");
+            expect(wrapper.vm.zoom).toBe(zoom);
+            expect(wrapper.vm.centre).toEqual(centre);
+          });
         });
       });
     });
+
+    //   describe("hash", () => {
+    //     afterEach(() => {
+    //       window.location.hash = undefined;
+    //     });
+
+    //     describe("when `true`", () => {
+    //       const hash = true;
+
+    //       it("reads centre and zoom from window.location.hash", () => {
+    //         window.location.hash = "#em-id=map&em-z=5&em-c=-5%2C36";
+    //         const wrapper = factory({ props: { hash } });
+
+    //         const map = wrapper.vm.map;
+
+    //         expect(map.getView().getCenter()).toEqual([-5, 36]);
+    //         expect(map.getView().getZoom()).toBe(5);
+    //       });
+    //     });
+
+    //     describe("when `false` (default)", () => {
+    //       it("ignores centre and zoom from window.location.hash", () => {
+    //         window.location.hash = "#em-id=map&em-z=5&em-c=-5%2C36";
+    //         const wrapper = factory();
+
+    //         const map = wrapper.vm.map;
+
+    //         expect(map.getView().getCenter()).not.toEqual([-5, 36]);
+    //         expect(map.getView().getZoom()).not.toBe(5);
+    //       });
+
+    //       it("does not update hash with centre and zoom on moveend event", () => {
+    //         const centre = [-5, 36];
+    //         const zoom = 5;
+    //         const wrapper = factory({ props: { centre, zoom } });
+
+    //         const map = wrapper.vm.map;
+    //         map.dispatchEvent("moveend");
+
+    //         expect(window.location.hash).not.toBe("#c=-5%2C36&z=5");
+    //       });
+    //     });
+    //   });
   });
 });


### PR DESCRIPTION
- makes centre and zoom into shared refs that are passed around the composables
- makes `useOpenLayersMap` responsible for updating the values of those refs when the map is moved
- creates a new composable `useLocationHash` which:
  - initialises the shared centre and zoom refs from the location hash
  - updates the location hash when the refs change